### PR TITLE
Enable CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - name: setup
-      run: sudo apt-get update && sudo apt-get install ninja-build
+      run: sudo apt-get update && sudo apt-get install ninja-build qtdeclarative5-dev
     - uses: actions/checkout@v2
     - name: make
       run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -GNinja .. && ninja


### PR DESCRIPTION
This enables continuous integration that runs tests on every commit. 
With some adjustions this can also automatically build binaries for linux (and proably also windows). 