### PR TITLE
Player stats class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,7 @@ set_target_properties(gtest gtest_main PROPERTIES FOLDER "third_party")
 add_library(FreeAgeLib
   src/FreeAge/common/building_types.cpp
   src/FreeAge/common/messages.cpp
+  src/FreeAge/common/player.cpp
   src/FreeAge/common/timing.cpp
   src/FreeAge/common/unit_types.cpp
 )

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -465,7 +465,10 @@ void GameController::HandleChangeUnitTypeMessage(const QByteArray& data) {
   }
   
   ClientUnit* unit = AsUnit(it->second);
+  UnitType oldType = unit->GetType();
   unit->SetType(newType);
+
+  playerStats.UnitTransformed(oldType, newType);
 }
 
 void GameController::HandleSetCarriedResourcesMessage(const QByteArray& data) {

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -268,10 +268,12 @@ void GameController::HandleAddObjectMessage(const QByteArray& data) {
     
     ClientBuilding* newBuilding = new ClientBuilding(playerIndex, buildingType, baseTile.x(), baseTile.y(), buildPercentage, initialHP);
     map->AddObject(objectId, newBuilding);
-    if (playerIndex == match->GetPlayerIndex() && buildPercentage == 100) {
-      availablePopulationSpace += GetBuildingProvidedPopulationSpace(buildingType);
-      
-      newBuilding->UpdateFieldOfView(map.get(), 1);
+    if (playerIndex == match->GetPlayerIndex()) {
+      playerStats.BuildingAdded(buildingType, buildPercentage == 100);
+
+      if (buildPercentage == 100) {
+        newBuilding->UpdateFieldOfView(map.get(), 1);
+      }
     }
   } else if (objectType == ObjectType::Unit) {
     UnitType unitType = static_cast<UnitType>(mango::uload16(buffer + 10));
@@ -286,7 +288,7 @@ void GameController::HandleAddObjectMessage(const QByteArray& data) {
     ClientUnit* newUnit = new ClientUnit(playerIndex, unitType, mapCoord, initialHP);
     map->AddObject(objectId, newUnit);
     if (playerIndex == match->GetPlayerIndex()) {
-      populationCount += 1;
+      playerStats.UnitAdded(newUnit->GetType());
       
       newUnit->UpdateFieldOfView(map.get(), 1);
     }
@@ -322,20 +324,23 @@ void GameController::HandleObjectDeathMessage(const QByteArray& data) {
       renderWindow->AddDecal(newDecal);
       
       if (building->GetPlayerIndex() == match->GetPlayerIndex()) {
-        // Subtract the population space that this building gave.
-        availablePopulationSpace -= GetBuildingProvidedPopulationSpace(building->GetType());
-        
+        playerStats.BuildingRemoved(building->GetType(), true);
+
         object->UpdateFieldOfView(map.get(), -1);
       }
     } else {
       // TODO: Destruction animations for foundations
+
+      if (building->GetPlayerIndex() == match->GetPlayerIndex()) {
+        playerStats.BuildingRemoved(building->GetType(), false);
+      }
     }
   } else if (object->isUnit()) {
     Decal* newDecal = new Decal(AsUnit(object), map.get(), currentGameStepServerTime);
     renderWindow->AddDecal(newDecal);
     
     if (object->GetPlayerIndex() == match->GetPlayerIndex()) {
-      populationCount -= 1;
+      playerStats.UnitRemoved(AsUnit(object)->GetType());
       
       object->UpdateFieldOfView(map.get(), -1);
     }
@@ -424,11 +429,11 @@ void GameController::HandleBuildPercentageUpdate(const QByteArray& data) {
   memcpy(&percentage, buffer + 4, 4);
   
   ClientBuilding* building = AsBuilding(it->second);
-  if (building->GetBuildPercentage() != 100 && percentage == 100) {
-    // The building has been completed.
-    if (building->GetPlayerIndex() == match->GetPlayerIndex()) {
-      availablePopulationSpace += GetBuildingProvidedPopulationSpace(building->GetType());
-      
+  if (building->GetPlayerIndex() == match->GetPlayerIndex()) {
+    if (building->GetBuildPercentage() != 100 && percentage == 100) {
+      // The building has been completed.
+      playerStats.BuildingFinished(building->GetType());
+
       building->UpdateFieldOfView(map.get(), 1);
     }
   }

--- a/src/FreeAge/client/game_controller.hpp
+++ b/src/FreeAge/client/game_controller.hpp
@@ -13,6 +13,7 @@
 #include "FreeAge/client/match.hpp"
 #include "FreeAge/client/render_window.hpp"
 #include "FreeAge/client/server_connection.hpp"
+#include "FreeAge/common/player.hpp"
 
 /// Handles the game on the client side:
 /// * Handles incoming messages from the server
@@ -38,11 +39,12 @@ class GameController : public QObject {
   // TODO: Remove? Does not seem really useful and we cannot get this unless we peek into messages just for it.
   inline const ResourceAmount& GetLatestKnownResourceAmount() { return /*latestKnownPlayerResources*/ playerResources; }
   
-  inline int GetPopulationCount() const { return populationCount; }
-  inline int GetAvailablePopulationSpace() const { return availablePopulationSpace; }
+  inline int GetPopulationCount() const { return playerStats.GetPopulationCount(); }
+  inline int GetAvailablePopulationSpace() const { return playerStats.GetAvailablePopulationSpace(); }
+  inline int GetBuildingTypeCount(BuildingType buildingType) const { return playerStats.GetBuildingTypeCount(buildingType); }
   
   inline bool IsPlayerHoused() const { return isHoused; }
-  
+
   inline double GetGameStartServerTimeSeconds() const { return gameStartServerTimeSeconds; }
   
   inline void SetLastDisplayedServerTime(double serverTime) { lastDisplayedServerTime = serverTime; }
@@ -85,14 +87,11 @@ class GameController : public QObject {
   
   /// The resources of the player.
   ResourceAmount playerResources;
-  
-  /// The current population count.
-  int populationCount = 0;
-  
-  /// The available population space.
-  int availablePopulationSpace = 0;
-  
-  /// Whether the player is currenly housed.
+
+  /// The current stats of the player
+  PlayerStats playerStats;
+
+  /// Whether the player is currently housed.
   bool isHoused = false;
   
   /// The last server time that has been used to display the game state in the render window.

--- a/src/FreeAge/client/map.cpp
+++ b/src/FreeAge/client/map.cpp
@@ -335,6 +335,16 @@ void Map::AddObject(u32 objectId, ClientObject* object) {
   objects.insert(std::make_pair(objectId, object));
 }
 
+void Map::DeleteObject(u32 objectId) {
+  auto it = objects.find(objectId);
+  if (it == objects.end()) {
+    LOG(ERROR) << "Cannot find to erase object id: " << objectId;
+    return;
+  }
+  delete it->second;
+  objects.erase(it);
+}
+
 bool Map::IsUnitInFogOfWar(ClientUnit* unit) {
   int tileX = std::max<int>(0, std::min<int>(width - 1, unit->GetMapCoord().x()));
   int tileY = std::max<int>(0, std::min<int>(height - 1, unit->GetMapCoord().y()));

--- a/src/FreeAge/client/map.hpp
+++ b/src/FreeAge/client/map.hpp
@@ -95,6 +95,7 @@ class Map {
   inline const std::unordered_map<u32, ClientObject*>& GetObjects() const { return objects; }
   
   void AddObject(u32 objectId, ClientObject* object);
+  void DeleteObject(u32 objectId);
   
   bool IsUnitInFogOfWar(ClientUnit* unit);
   bool IsBuildingInFogOfWar(ClientBuilding* building);

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3046,6 +3046,10 @@ void RenderWindow::ShowEconomyBuildingCommandButtons() {
   commandButtons[0][2].SetBuilding(BuildingType::MiningCamp, Qt::Key_E);
   commandButtons[0][3].SetBuilding(BuildingType::LumberCamp, Qt::Key_R);
   commandButtons[0][4].SetBuilding(BuildingType::Dock, Qt::Key_T);
+
+  if (gameController->GetBuildingTypeCount(BuildingType::TownCenter) != GetBuildingMaxInstances(BuildingType::TownCenter)) {
+    commandButtons[1][0].SetBuilding(BuildingType::TownCenter, Qt::Key_A);
+  }
   
   commandButtons[2][3].SetAction(CommandButton::ActionType::ToggleBuildingsCategory, toggleBuildingsCategory.texture.get());
   commandButtons[2][4].SetAction(CommandButton::ActionType::Quit, quit.texture.get(), Qt::Key_Escape);

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -269,6 +269,7 @@ bool RenderWindow::LoadResources() {
     emit LoadingProgressUpdated(static_cast<int>(100 * loadingStep / static_cast<float>(maxLoadingStep) + 0.5f));
   };
   
+  Timer timer("LoadResources()");
   LOG(1) << "LoadResource() start";
 
   const GLubyte* glVendor = f->glGetString(GL_VENDOR);
@@ -360,6 +361,7 @@ bool RenderWindow::LoadResources() {
   auto& unitTypes = ClientUnitType::GetUnitTypes();
   unitTypes.resize(static_cast<int>(UnitType::NumUnits));
   for (int unitType = 0; unitType < static_cast<int>(UnitType::NumUnits); ++ unitType) {
+    Timer timer("LoadResources() - Load unit");
     if (!unitTypes[unitType].Load(static_cast<UnitType>(unitType), graphicsSubPath, cachePath, colorDilationShader.get(), palettes)) {
       LOG(ERROR) << "Exiting because of a resource load error for unit " << unitType << ".";
       emit LoadingError(tr("Failed to load unit type: %1. Aborting.").arg(unitType));
@@ -375,6 +377,7 @@ bool RenderWindow::LoadResources() {
   auto& buildingTypes = ClientBuildingType::GetBuildingTypes();
   buildingTypes.resize(static_cast<int>(BuildingType::NumBuildings));
   for (int buildingType = 0; buildingType < static_cast<int>(BuildingType::NumBuildings); ++ buildingType) {
+    Timer timer("LoadResources() - Load building");
     if (!buildingTypes[buildingType].Load(static_cast<BuildingType>(buildingType), graphicsSubPath, cachePath, colorDilationShader.get(), palettes)) {
       LOG(ERROR) << "Exiting because of a resource load error for building " << buildingType << ".";
       emit LoadingError(tr("Failed to load building type: %1. Aborting.").arg(buildingType));
@@ -553,6 +556,8 @@ bool RenderWindow::LoadResources() {
   iconOverlayActiveTexture->Load(QImage(GetModdedPathAsQString(ingameIconsSubPath / "icon_overlay_active.png")), GL_CLAMP_TO_EDGE, GL_LINEAR, GL_LINEAR);
   didLoadingStep();
   
+  timer.Stop();
+
   // Output timings of the resource loading processes and clear those statistics from further timing prints.
   LOG(INFO) << "Loading timings:";
   Timing::print(std::cout, kSortByTotal);
@@ -3048,7 +3053,7 @@ void RenderWindow::ShowEconomyBuildingCommandButtons() {
   commandButtons[0][4].SetBuilding(BuildingType::Dock, Qt::Key_T);
 
   if (gameController->GetBuildingTypeCount(BuildingType::TownCenter) != GetBuildingMaxInstances(BuildingType::TownCenter)) {
-    commandButtons[1][0].SetBuilding(BuildingType::TownCenter, Qt::Key_A);
+    commandButtons[2][0].SetBuilding(BuildingType::TownCenter, Qt::Key_Z);
   }
   
   commandButtons[2][3].SetAction(CommandButton::ActionType::ToggleBuildingsCategory, toggleBuildingsCategory.texture.get());

--- a/src/FreeAge/common/building_types.cpp
+++ b/src/FreeAge/common/building_types.cpp
@@ -218,6 +218,16 @@ u32 GetBuildingMeleeArmor(BuildingType type) {
   return 0;
 }
 
+int GetBuildingMaxInstances(BuildingType type) {
+  if (type == BuildingType::TownCenter) { // TODO: add wonder
+    return 1;
+  } else if (type >= BuildingType::House && type <= BuildingType::PalisadeGate) {
+    // TODO: use infinity instead of -1 ?
+    return -1; // unlimited
+  }
+  return 0;
+}
+
 int GetBuildingProvidedPopulationSpace(BuildingType type) {
   if (type == BuildingType::House || type == BuildingType::TownCenter) {
     return 5;

--- a/src/FreeAge/common/building_types.cpp
+++ b/src/FreeAge/common/building_types.cpp
@@ -222,7 +222,6 @@ int GetBuildingMaxInstances(BuildingType type) {
   if (type == BuildingType::TownCenter) { // TODO: add wonder
     return 1;
   } else if (type >= BuildingType::House && type <= BuildingType::PalisadeGate) {
-    // TODO: use infinity instead of -1 ?
     return -1; // unlimited
   }
   return 0;

--- a/src/FreeAge/common/building_types.hpp
+++ b/src/FreeAge/common/building_types.hpp
@@ -63,6 +63,9 @@ bool IsDropOffPointForResource(BuildingType building, ResourceType resource);
 u32 GetBuildingMaxHP(BuildingType type);
 u32 GetBuildingMeleeArmor(BuildingType type);
 
+/// TODO: This needs to consider the player's age.
+int GetBuildingMaxInstances(BuildingType type);
+
 int GetBuildingProvidedPopulationSpace(BuildingType type);
 
 float GetBuildingLineOfSight(BuildingType type);

--- a/src/FreeAge/common/building_types.hpp
+++ b/src/FreeAge/common/building_types.hpp
@@ -63,7 +63,10 @@ bool IsDropOffPointForResource(BuildingType building, ResourceType resource);
 u32 GetBuildingMaxHP(BuildingType type);
 u32 GetBuildingMeleeArmor(BuildingType type);
 
+/// Returns the max number of the given building type that the player can build.
+/// Returns -1 if unlimited.
 /// TODO: This needs to consider the player's age.
+/// TODO: use infinity instead of -1 ?
 int GetBuildingMaxInstances(BuildingType type);
 
 int GetBuildingProvidedPopulationSpace(BuildingType type);

--- a/src/FreeAge/common/player.cpp
+++ b/src/FreeAge/common/player.cpp
@@ -1,0 +1,88 @@
+// Copyright 2020 The FreeAge authors
+// This file is part of FreeAge, licensed under the new BSD license.
+// See the COPYING file in the project root for the license text.
+
+#include "FreeAge/common/player.hpp"
+
+PlayerStats::PlayerStats() {
+
+  for (int buildingType = 0; buildingType < static_cast<int>(BuildingType::NumBuildings); ++ buildingType) {
+    buildingConstructions[buildingType] = 0;
+    buildingAlive[buildingType] = 0;
+    buildingExisted[buildingType] = false;
+  }
+
+  for (int unitType = 0; unitType < static_cast<int>(UnitType::NumUnits); ++ unitType) {
+    unitsAlive[unitType] = 0;
+  }
+}
+
+PlayerStats::~PlayerStats() {
+
+}
+
+// interface methods
+
+void PlayerStats::BuildingAdded(BuildingType buildingType, bool finished) {
+  if (finished) {
+    FinishedBuildingChange(buildingType, 1);
+  } else {
+    UnfinishedBuildingChange(buildingType, 1);
+  }
+}
+
+void PlayerStats::UnitAdded(UnitType unitType) {
+  UnitChange(unitType, false, 1);
+}
+
+void PlayerStats::BuildingRemoved(BuildingType buildingType, bool finished) {
+  if (finished) {
+    FinishedBuildingChange(buildingType, -1);
+  } else {
+    UnfinishedBuildingChange(buildingType, -1);
+  }
+}
+
+void PlayerStats::UnitRemoved(UnitType unitType) {
+  UnitChange(unitType, true, -1);
+}
+
+void PlayerStats::BuildingTransformed(BuildingType fromBuildingType, BuildingType toBuildingType) {
+  FinishedBuildingChange(fromBuildingType, -1);
+  FinishedBuildingChange(toBuildingType, 1);
+}
+void PlayerStats::UnitTransformed(UnitType fromUnitType, UnitType toUnitType) {
+  UnitChange(fromUnitType, false, -1);
+  UnitChange(toUnitType, false, 1);
+}
+
+void PlayerStats::BuildingFinished(BuildingType buildingType) {
+  UnfinishedBuildingChange(buildingType, -1);
+  FinishedBuildingChange(buildingType, 1);
+}
+
+// core methods
+
+void PlayerStats::UnfinishedBuildingChange(BuildingType buildingType, int d) {
+
+  buildingConstructions[static_cast<int>(buildingType)] += d;
+}
+
+void PlayerStats::FinishedBuildingChange(BuildingType buildingType, int d) {
+
+  buildingAlive[static_cast<int>(buildingType)] += d;
+  if (d > 0) buildingExisted[static_cast<int>(buildingType)] = true;
+
+  availablePopulationSpace += d * GetBuildingProvidedPopulationSpace(buildingType);
+
+  // TODO: implement special case: Feitoria
+}
+
+void PlayerStats::UnitChange(UnitType unitType, bool death, int d) {
+  assert(!death || d < 0); // death => d < 0
+
+  populationCount += d;
+
+  unitsAlive[static_cast<int>(unitType)] += d;
+  if (death) unitsDied[static_cast<int>(unitType)] += -d;
+}

--- a/src/FreeAge/common/player.cpp
+++ b/src/FreeAge/common/player.cpp
@@ -6,19 +6,20 @@
 
 PlayerStats::PlayerStats() {
 
+  for (int unitType = 0; unitType < static_cast<int>(UnitType::NumUnits); ++ unitType) {
+    unitsAlive[unitType] = 0;
+    unitsDied[unitType] = 0;
+  }
+
   for (int buildingType = 0; buildingType < static_cast<int>(BuildingType::NumBuildings); ++ buildingType) {
     buildingConstructions[buildingType] = 0;
     buildingAlive[buildingType] = 0;
     buildingExisted[buildingType] = false;
   }
-
-  for (int unitType = 0; unitType < static_cast<int>(UnitType::NumUnits); ++ unitType) {
-    unitsAlive[unitType] = 0;
-  }
 }
 
 PlayerStats::~PlayerStats() {
-
+  // empty
 }
 
 // interface methods
@@ -66,6 +67,8 @@ void PlayerStats::BuildingFinished(BuildingType buildingType) {
 void PlayerStats::UnfinishedBuildingChange(BuildingType buildingType, int d) {
 
   buildingConstructions[static_cast<int>(buildingType)] += d;
+
+  Change();
 }
 
 void PlayerStats::FinishedBuildingChange(BuildingType buildingType, int d) {
@@ -76,6 +79,8 @@ void PlayerStats::FinishedBuildingChange(BuildingType buildingType, int d) {
   availablePopulationSpace += d * GetBuildingProvidedPopulationSpace(buildingType);
 
   // TODO: implement special case: Feitoria
+
+  Change();
 }
 
 void PlayerStats::UnitChange(UnitType unitType, bool death, int d) {
@@ -85,4 +90,32 @@ void PlayerStats::UnitChange(UnitType unitType, bool death, int d) {
 
   unitsAlive[static_cast<int>(unitType)] += d;
   if (death) unitsDied[static_cast<int>(unitType)] += -d;
+
+  Change();
+}
+
+void PlayerStats::Change() {
+
+  // log();
+}
+
+void PlayerStats::log() const {
+  LOG(INFO) << "--- Stats";
+
+  for (int unitType = 0; unitType < static_cast<int>(UnitType::NumUnits); ++ unitType) {
+    if (!unitsAlive[unitType] && !unitsDied[unitType]) continue;
+
+    LOG(INFO) << GetUnitName(static_cast<UnitType>(unitType)).toStdString() << "(" << unitType << ")"
+        << " " << unitsAlive[unitType]
+        << " " << unitsDied[unitType];
+  }
+
+  for (int buildingType = 0; buildingType < static_cast<int>(BuildingType::NumBuildings); ++ buildingType) {
+    if (!buildingExisted[buildingType] && !buildingAlive[buildingType] && !buildingConstructions[buildingType]) continue;
+
+    LOG(INFO) << GetBuildingName(static_cast<BuildingType>(buildingType)).toStdString() << "(" << buildingType << ")"
+        << " " << buildingExisted[buildingType]
+        << " " << buildingAlive[buildingType]
+        << " " << buildingConstructions[buildingType];
+  }
 }

--- a/src/FreeAge/common/player.hpp
+++ b/src/FreeAge/common/player.hpp
@@ -8,24 +8,42 @@
 #include "FreeAge/common/building_types.hpp"
 #include "FreeAge/common/unit_types.hpp"
 
+/// A collection of stats for a player.
+/// All of the stats can be reproduced from the game state, but they are kept track of here
+/// for performace and ease of access to them.
+///
+/// Extension to the game logic should go at the private *Change methods:
+///
+///   void UnfinishedBuildingChange(BuildingType buildingType, int d)
+///   void FinishedBuildingChange(BuildingType buildingType, int d)
+///   void UnitChange(UnitType unitType, bool death, int d)
+///   void Change()
+///
 struct PlayerStats {
  public:
 
   PlayerStats(); // TODO: pass the whatever the GetBuildingProvidedPopulationSpace will need
   ~PlayerStats();
 
+  /// Called when new building is added.
   void BuildingAdded(BuildingType buildingType, bool finished);
 
+  /// Called when new unit is added.
   void UnitAdded(UnitType unitType);
 
+  /// Called when a building is destroyed.
   void BuildingRemoved(BuildingType buildingType, bool finished);
 
+  /// Called when new unit is killed.
   void UnitRemoved(UnitType unitType);
 
+  /// Called when a building changes type.
   void BuildingTransformed(BuildingType fromBuildingType, BuildingType toBuildingType);
 
+  /// Called when a unit changes type.
   void UnitTransformed(UnitType fromUnitType, UnitType toUnitType);
 
+  /// Called when a building construction is completeted.
   void BuildingFinished(BuildingType buildingType);
 
   /// TODO: implement, note that research can add population space
@@ -48,22 +66,33 @@ struct PlayerStats {
     return buildingExisted[static_cast<int>(buildingType)];
   }
 
-private:
+  // debug
+
+  void log() const;
+
+ private:
 
   // core methods
 
+  /// Called when the number of unfinished buildings change.
   void UnfinishedBuildingChange(BuildingType buildingType, int d);
 
+  /// Called when the number of finished buildings change.
   void FinishedBuildingChange(BuildingType buildingType, int d);
 
+  /// Called when the number of units change.
   void UnitChange(UnitType unitType, bool death, int d);
 
-  // TODO: change from arrays to maps if the sizeof(PlayerStats) gets too big
+  /// Called when something change.
+  void Change();
+
+  // TODO: change from arrays to maps if the sizeof(PlayerStats) gets too big ?
+  // TODO: merge array of ints to a single array of structs ?
 
   /// The number of units alive per unit type.
   int unitsAlive[static_cast<int>(UnitType::NumUnits)];
 
-  /// The number of units died per unit type
+  /// The number of units died per unit type.
   int unitsDied[static_cast<int>(UnitType::NumUnits)];
 
   /// The current population count.

--- a/src/FreeAge/common/player.hpp
+++ b/src/FreeAge/common/player.hpp
@@ -46,13 +46,22 @@ struct PlayerStats {
   /// Called when a building construction is completeted.
   void BuildingFinished(BuildingType buildingType);
 
-  /// TODO: implement, note that research can add population space
+  /// TODO: implement, note that research can add population space.
   void ResearchCompleted(/* TODO */) {};
+
+  /// The population of the units that are currently being produced.
+  /// TODO: implement on the client, now only used by the server
+  int populationInProduction = 0;
 
   // getters
 
   inline int GetPopulationCount() const { return populationCount; }
   inline int GetAvailablePopulationSpace() const { return availablePopulationSpace; }
+
+  /// The current population count of this player,
+  /// *including units being produced*. This is required for "housed" checking,
+  /// and it is different from the population count shown to the client.
+  inline int GetPopulationCountIncludingInProduction() const { return populationCount + populationInProduction; }
 
   /// The number of buildings with the given type that have been constructred
   /// or are under construction.

--- a/src/FreeAge/common/player.hpp
+++ b/src/FreeAge/common/player.hpp
@@ -1,0 +1,84 @@
+// Copyright 2020 The FreeAge authors
+// This file is part of FreeAge, licensed under the new BSD license.
+// See the COPYING file in the project root for the license text.
+
+#pragma once
+
+#include "FreeAge/common/free_age.hpp"
+#include "FreeAge/common/building_types.hpp"
+#include "FreeAge/common/unit_types.hpp"
+
+struct PlayerStats {
+ public:
+
+  PlayerStats(); // TODO: pass the whatever the GetBuildingProvidedPopulationSpace will need
+  ~PlayerStats();
+
+  void BuildingAdded(BuildingType buildingType, bool finished);
+
+  void UnitAdded(UnitType unitType);
+
+  void BuildingRemoved(BuildingType buildingType, bool finished);
+
+  void UnitRemoved(UnitType unitType);
+
+  void BuildingTransformed(BuildingType fromBuildingType, BuildingType toBuildingType);
+
+  void UnitTransformed(UnitType fromUnitType, UnitType toUnitType);
+
+  void BuildingFinished(BuildingType buildingType);
+
+  /// TODO: implement, note that research can add population space
+  void ResearchCompleted(/* TODO */) {};
+
+  // getters
+
+  inline int GetPopulationCount() const { return populationCount; }
+  inline int GetAvailablePopulationSpace() const { return availablePopulationSpace; }
+
+  /// The number of buildings with the given type that have been constructred
+  /// or are under construction.
+  inline int GetBuildingTypeCount(BuildingType buildingType) const {
+    int i = static_cast<int>(buildingType);
+    return buildingConstructions[i] + buildingAlive[i];
+  }
+
+  /// If a building of the given type have ever been constructed.
+  inline bool GetBuildingTypeExisted(BuildingType buildingType) const {
+    return buildingExisted[static_cast<int>(buildingType)];
+  }
+
+private:
+
+  // core methods
+
+  void UnfinishedBuildingChange(BuildingType buildingType, int d);
+
+  void FinishedBuildingChange(BuildingType buildingType, int d);
+
+  void UnitChange(UnitType unitType, bool death, int d);
+
+  // TODO: change from arrays to maps if the sizeof(PlayerStats) gets too big
+
+  /// The number of units alive per unit type.
+  int unitsAlive[static_cast<int>(UnitType::NumUnits)];
+
+  /// The number of units died per unit type
+  int unitsDied[static_cast<int>(UnitType::NumUnits)];
+
+  /// The current population count.
+  int populationCount = 0;
+
+  /// The available population space.
+  int availablePopulationSpace = 0;
+
+  /// The number of buildings under construction per building type.
+  int buildingConstructions[static_cast<int>(BuildingType::NumBuildings)];
+
+  /// The number of built buildings per building type.
+  int buildingAlive[static_cast<int>(BuildingType::NumBuildings)];
+
+  /// If a building has ever been constructed per building type.
+  bool buildingExisted[static_cast<int>(BuildingType::NumBuildings)];
+
+};

--- a/src/FreeAge/server/game.cpp
+++ b/src/FreeAge/server/game.cpp
@@ -335,8 +335,15 @@ void Game::HandlePlaceBuildingFoundationMessage(const QByteArray& msg, PlayerInG
   const char* data = msg.data();
   
   BuildingType type = static_cast<BuildingType>(mango::uload16(data + 3));
-  // TODO: Check whether the player is allowed to build this type of building
-  
+
+  // check whether the player is allowed to build this type of building
+  int max = GetBuildingMaxInstances(type);
+  bool maxReached = max != -1 && player->stats.GetBuildingTypeCount(type) >= max;
+  if (maxReached) {
+    LOG(ERROR) << "Received a PlaceBuildingFoundation message for which the player cannot build";
+    return;
+  }
+
   QSize foundationSize = GetBuildingSize(type);
   QPoint baseTile(
       mango::uload16(data + 5),
@@ -407,6 +414,8 @@ void Game::HandlePlaceBuildingFoundationMessage(const QByteArray& msg, PlayerInG
   u32 newBuildingId;
   ServerBuilding* newBuildingFoundation = map->AddBuilding(player->index, type, baseTile, /*buildPercentage*/ 0, &newBuildingId, /*addOccupancy*/ false);
   
+  player->stats.BuildingAdded(type, false);
+
   QByteArray addObjectMsg = CreateAddObjectMessage(newBuildingId, newBuildingFoundation);
   accumulatedMessages[player->index] += addObjectMsg;
   
@@ -474,7 +483,7 @@ void Game::HandleDequeueProductionQueueItemMessage(const QByteArray& msg, Player
   
   // Adjust population count (if relevant).
   if (queueIndex == 0 && building->GetProductionPercentage() > 0) {
-    playersInGame->at(building->GetPlayerIndex())->populationIncludingInProduction -= 1;
+    playersInGame->at(building->GetPlayerIndex())->stats.populationInProduction -= 1;
   }
   
   // Remove the item from the queue.
@@ -668,7 +677,7 @@ void Game::StartGame() {
     player->socket->write(mapUncoverMsg);
   }
   
-  // Send creation messages for the initial map objects and count initial population
+  // Send creation messages for the initial map objects and update stats
   const auto& objects = map->GetObjects();
   for (const auto& item : objects) {
     ServerObject* object = item.second;
@@ -680,11 +689,9 @@ void Game::StartGame() {
     
     if (object->isBuilding()) {
       ServerBuilding* building = AsBuilding(object);
-      if (building->GetPlayerIndex() != kGaiaPlayerIndex) {
-        playersInGame->at(building->GetPlayerIndex())->availablePopulationSpace += GetBuildingProvidedPopulationSpace(building->GetBuildingType());
-      }
+      GetPlayerStats(building->GetPlayerIndex())->BuildingAdded(building->GetBuildingType(), true);
     } else if (object->isUnit()) {
-      playersInGame->at(object->GetPlayerIndex())->populationIncludingInProduction += 1;
+      GetPlayerStats(object->GetPlayerIndex())->UnitAdded(AsUnit(object)->GetUnitType());
     }
   }
   for (auto& player : *playersInGame) {
@@ -692,6 +699,10 @@ void Game::StartGame() {
   }
   
   LOG(INFO) << "Server: Game start prepared";
+  gaiStats.log();
+  for (auto& player : *playersInGame) {
+    player->stats.log();
+  }
 }
 
 void Game::SimulateGameStep(double gameStepServerTime, float stepLengthInSeconds) {
@@ -1584,7 +1595,7 @@ void Game::SimulateBuildingConstruction(float stepLengthInSeconds, ServerUnit* v
     if (newPercentage == 100 && targetBuilding->GetBuildPercentage() != 100) {
       // Building completed.
       if (targetBuilding->GetPlayerIndex() != kGaiaPlayerIndex) {
-        playersInGame->at(targetBuilding->GetPlayerIndex())->availablePopulationSpace += GetBuildingProvidedPopulationSpace(targetBuilding->GetBuildingType());
+        GetPlayerStats(targetBuilding->GetPlayerIndex())->BuildingFinished(targetBuilding->GetBuildingType());
       }
     }
     targetBuilding->SetBuildPercentage(newPercentage);
@@ -1737,7 +1748,7 @@ void Game::SimulateGameStepForBuilding(u32 buildingId, ServerBuilding* building,
     float previousPercentage = building->GetProductionPercentage();
     if (previousPercentage == 0) {
       // Only start producing the unit if population space is available.
-      canProduce = player.populationIncludingInProduction < player.availablePopulationSpace;
+      canProduce = player.stats.GetPopulationCountIncludingInProduction() < player.stats.GetAvailablePopulationSpace();
       if (!canProduce) {
         player.isHoused = true;
       }
@@ -1751,7 +1762,7 @@ void Game::SimulateGameStepForBuilding(u32 buildingId, ServerBuilding* building,
       bool completed = false;
       if (newPercentage >= 100) {
         // Remove the population count for the unit in production.
-        player.populationIncludingInProduction -= 1;
+        player.stats.populationInProduction -= 1;
         
         // Special case for UnitType::MaleVillager: Randomly decide whether to produce a male or female.
         if (unitInProduction == UnitType::MaleVillager) {
@@ -1773,7 +1784,7 @@ void Game::SimulateGameStepForBuilding(u32 buildingId, ServerBuilding* building,
         accumulatedMessages[building->GetPlayerIndex()] += CreateUpdateProductionMessage(buildingId, building->GetProductionPercentage(), 100.f / productionTime);
         
         // Add the population count for the unit in production.
-        player.populationIncludingInProduction += 1;
+        player.stats.populationInProduction += 1;
       }
     }
   }
@@ -1927,8 +1938,7 @@ void Game::ProduceUnit(ServerBuilding* building, UnitType unitInProduction) {
     accumulatedMessages[player->index] += addObjectMsg;
   }
   
-  // Handle population counting
-  playersInGame->at(newUnit->GetPlayerIndex())->populationIncludingInProduction += 1;
+  GetPlayerStats(newUnit->GetPlayerIndex())->UnitAdded(unitInProduction);
 }
 
 void Game::SetUnitTargets(const std::vector<u32>& unitIds, int playerIndex, u32 targetId, ServerObject* targetObject, bool isManualTargeting) {
@@ -1947,6 +1957,7 @@ void Game::SetUnitTargets(const std::vector<u32>& unitIds, int playerIndex, u32 
     unit->SetTarget(targetId, targetObject, isManualTargeting);
     
     if (oldUnitType != unit->GetUnitType()) {
+      GetPlayerStats(playerIndex)->UnitTransformed(oldUnitType, unit->GetUnitType());
       // Notify all clients that see the unit about its change of type.
       QByteArray msg = CreateChangeUnitTypeMessage(id, unit->GetUnitType());
       for (auto& player : *playersInGame) {
@@ -1978,15 +1989,10 @@ void Game::DeleteObject(u32 objectId, bool deletedManually) {
   }
   ServerObject* object = it->second;
   
-  bool sendObjectDeathToOwningPlayerOnly = false;
-  if (object->isBuilding()) {
-    ServerBuilding* building = AsBuilding(object);
-    if (building->GetBuildPercentage() == 0) {
-      // For building foundations, only the player that owns them knows about the object.
-      // So we only need to send the object death message to this player.
-      sendObjectDeathToOwningPlayerOnly = true;
-    }
-  }
+  // For building foundations, only the player that owns them knows about the object.
+  // So we only need to send the object death message to this player.
+  bool isFoundation = object->isBuilding() && AsBuilding(object)->GetBuildPercentage() == 0;
+  bool sendObjectDeathToOwningPlayerOnly = isFoundation;
   
   QByteArray msg = CreateObjectDeathMessage(objectId);
   for (auto& player : *playersInGame) {
@@ -2019,19 +2025,16 @@ void Game::DeleteObject(u32 objectId, bool deletedManually) {
       playersInGame->at(building->GetPlayerIndex())->resources.Add(GetUnitCost(building->GetProductionQueue()[queueIndex]));
     }
     if (building->GetProductionPercentage() > 0) {
-      playersInGame->at(object->GetPlayerIndex())->populationIncludingInProduction -= 1;
+      playersInGame->at(object->GetPlayerIndex())->stats.populationInProduction -= 1;
     }
   }
   
-  // Handle population counting.
+  // Handle player stats.
   if (object->isBuilding()) {
     ServerBuilding* building = AsBuilding(object);
-    if (building->GetPlayerIndex() != kGaiaPlayerIndex &&
-        building->GetBuildPercentage() == 100) {
-      playersInGame->at(building->GetPlayerIndex())->availablePopulationSpace -= GetBuildingProvidedPopulationSpace(building->GetBuildingType());
-    }
+    GetPlayerStats(building->GetPlayerIndex())->BuildingRemoved(building->GetBuildingType(), building->GetBuildPercentage() == 100);
   } else if (object->isUnit()) {
-    playersInGame->at(object->GetPlayerIndex())->populationIncludingInProduction -= 1;
+    GetPlayerStats(object->GetPlayerIndex())->UnitRemoved(AsUnit(object)->GetUnitType());
   }
   
   // If all objects of a player are gone, the player gets defeated.

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -13,6 +13,7 @@
 
 #include "FreeAge/common/free_age.hpp"
 #include "FreeAge/common/messages.hpp"
+#include "FreeAge/common/player.hpp"
 #include "FreeAge/common/resources.hpp"
 #include "FreeAge/server/map.hpp"
 #include "FreeAge/server/settings.hpp"
@@ -58,14 +59,9 @@ struct PlayerInGame {
   /// needs to be sent to the client.
   ResourceAmount lastResources;
   
-  /// The current available population space of this player.
-  int availablePopulationSpace = 0;
-  
-  /// The current population count of this player,
-  /// *including units being produced*. This is required for "housed" checking,
-  /// and it is different from the population count shown to the client.
-  int populationIncludingInProduction = 0;
-  
+  /// The current stats of the player
+  PlayerStats stats;
+
   /// Whether the player is currently housed.
   /// This is reset to false at the beginning of each game step and set to true
   /// if any of the player's buildings cannot produce something due to lack of population space.
@@ -129,7 +125,6 @@ class Game {
   
   void RemovePlayer(int playerIndex, PlayerExitReason reason);
   
-  
   /// Stores the game map and the objects on it.
   std::shared_ptr<ServerMap> map;
   
@@ -143,6 +138,11 @@ class Game {
   
   /// List of players in the game.
   std::vector<std::shared_ptr<PlayerInGame>>* playersInGame;
+
+  /// The Gai's stats
+  PlayerStats gaiStats;
+
+  inline PlayerStats* GetPlayerStats(int playerIndex) { return &(playerIndex == kGaiaPlayerIndex ? gaiStats : playersInGame->at(playerIndex)->stats); }
   
   /// Stores the object IDs that should be deleted at the end of the current
   /// game step. This list is required since we generally cannot directly delete

--- a/src/FreeAge/test/test.cpp
+++ b/src/FreeAge/test/test.cpp
@@ -6,6 +6,7 @@
 #include <QApplication>
 
 #include "FreeAge/common/logging.hpp"
+#include "FreeAge/common/player.hpp"
 #include "FreeAge/client/map.hpp"
 
 int main(int argc, char** argv) {
@@ -78,4 +79,37 @@ TEST(Map, CoordinateConversion_HillyMap) {
   }
   
   TestProjectedCoordToMapCoord(testMap);
+}
+
+TEST(PlayerStats, Operations) {
+
+  PlayerStats stats;
+  LOG(INFO) << "sizeof(PlayerStats) = " << sizeof(PlayerStats);
+
+  EXPECT_EQ(stats.GetBuildingTypeCount(BuildingType::Barracks), 0);
+  EXPECT_FALSE(stats.GetBuildingTypeExisted(BuildingType::Barracks));
+
+  stats.BuildingAdded(BuildingType::House, true);
+  stats.BuildingAdded(BuildingType::House, false);
+  stats.BuildingAdded(BuildingType::Barracks, true);
+  stats.BuildingAdded(BuildingType::House, false);
+  stats.BuildingFinished(BuildingType::House);
+  stats.UnitAdded(UnitType::FemaleVillager);
+  stats.UnitAdded(UnitType::MaleVillager);
+
+  EXPECT_EQ(stats.GetAvailablePopulationSpace(), 10);
+  EXPECT_EQ(stats.GetPopulationCount(), 2);
+  EXPECT_EQ(stats.GetBuildingTypeCount(BuildingType::Barracks), 1);
+  EXPECT_TRUE(stats.GetBuildingTypeExisted(BuildingType::Barracks));
+
+  stats.BuildingRemoved(BuildingType::House, true);
+  stats.BuildingRemoved(BuildingType::Barracks, true);
+  stats.UnitTransformed(UnitType::FemaleVillager, UnitType::FemaleVillagerGoldMiner);
+  stats.UnitRemoved(UnitType::MaleVillager);
+
+  EXPECT_EQ(stats.GetAvailablePopulationSpace(), 5);
+  EXPECT_EQ(stats.GetPopulationCount(), 1);
+  EXPECT_EQ(stats.GetBuildingTypeCount(BuildingType::Barracks), 0);
+  EXPECT_TRUE(stats.GetBuildingTypeExisted(BuildingType::Barracks));
+
 }


### PR DESCRIPTION
I implemented the PlayerStats (#6) with the basic building, unit and population info.

All the game logic boils down to these methods:
```c++
  void UnfinishedBuildingChange(BuildingType buildingType, int d);
  void FinishedBuildingChange(BuildingType buildingType, int d);
  void UnitChange(UnitType unitType, bool death, int d);
  void Change();
```

As the number of types are very small (and there will be only `number of players` instances of the struct), I stored the per type info in arrays, however in the future (if needed) it can easyly be replaced with a map.

I used the PlayerStats in the client and added the TownCenter button under the needed condition.

I understand that the server needs its own things, however I think the server could use the PlayerStats (or a class that inherits form PlayerStats) to avoid the duplication of the basic game logic that keeps track of these stats.

The only diference at the moment is the `populationIncludingInProduction` which is only on the server, which could be added to the PlayerStats because it's info that the client does not need (at the moment) but it's not something that is not known/calculatable to client form the rest of the info.

Awesome code base by the way