### PR TITLE
Tree scale (Small trees)

### DIFF
--- a/src/FreeAge/client/building.cpp
+++ b/src/FreeAge/client/building.cpp
@@ -249,8 +249,7 @@ bool ClientBuildingType::DoesCauseOutlinesInternal() const {
 }
 
 bool ClientBuildingType::UsesRandomSpriteFrame() const {
-  return (static_cast<int>(type) >= static_cast<int>(BuildingType::FirstTree) &&
-          static_cast<int>(type) <= static_cast<int>(BuildingType::LastTree)) ||
+  return IsTree(type) ||
          type == BuildingType::House ||
          type == BuildingType::PalisadeWall ||
          type == BuildingType::ForageBush ||
@@ -283,6 +282,7 @@ void ClientBuildingType::SetCommandButtons(CommandButton commandButtons[3][5]) {
   }
 }
 
+float ClientBuilding::TreeScale = 1.f;
 
 ClientBuilding::ClientBuilding(int playerIndex, BuildingType type, int baseTileX, int baseTileY, float buildPercentage, u32 hp)
     : ClientObject(ObjectType::Building, playerIndex, hp),
@@ -309,11 +309,12 @@ QRectF ClientBuilding::GetRectInProjectedCoords(
   
   const Sprite::Frame::Layer& layer = shadow ? sprite.frame(frameIndex).shadow : sprite.frame(frameIndex).graphic;
   bool isGraphic = !shadow && !outline;
+  float scale = IsTree(type) ? TreeScale : 1.f;
   return QRectF(
-      centerProjectedCoord.x() - layer.centerX + (isGraphic ? 1 : 0),
-      centerProjectedCoord.y() - layer.centerY + (isGraphic ? 1 : 0),
-      layer.imageWidth + (isGraphic ? -2 : 0),
-      layer.imageHeight + (isGraphic ? -2 : 0));
+      centerProjectedCoord.x() - layer.centerX * scale + (isGraphic ? 1 : 0),
+      centerProjectedCoord.y() - layer.centerY * scale + (isGraphic ? 1 : 0),
+      layer.imageWidth * scale + (isGraphic ? -2 : 0),
+      layer.imageHeight * scale + (isGraphic ? -2 : 0));
 }
 
 void ClientBuilding::Render(
@@ -387,7 +388,7 @@ void ClientBuilding::Render(
       outline,
       outlineOrModulationColor,
       playerIndex,
-      1.f);
+      IsTree(type) ? TreeScale : 1.f);
   
   if (type == BuildingType::TownCenter && spriteType == BuildingSprite::Building) {
     // Front

--- a/src/FreeAge/client/building.cpp
+++ b/src/FreeAge/client/building.cpp
@@ -311,10 +311,10 @@ QRectF ClientBuilding::GetRectInProjectedCoords(
   bool isGraphic = !shadow && !outline;
   float scale = IsTree(type) ? TreeScale : 1.f;
   return QRectF(
-      centerProjectedCoord.x() - layer.centerX * scale + (isGraphic ? 1 : 0),
-      centerProjectedCoord.y() - layer.centerY * scale + (isGraphic ? 1 : 0),
-      layer.imageWidth * scale + (isGraphic ? -2 : 0),
-      layer.imageHeight * scale + (isGraphic ? -2 : 0));
+      centerProjectedCoord.x() + scale * (-layer.centerX + (isGraphic ? 1 : 0)),
+      centerProjectedCoord.y() + scale * (-layer.centerY + (isGraphic ? 1 : 0)),
+      scale * (layer.imageWidth + (isGraphic ? -2 : 0)),
+      scale * (layer.imageHeight + (isGraphic ? -2 : 0)));
 }
 
 void ClientBuilding::Render(

--- a/src/FreeAge/client/building.hpp
+++ b/src/FreeAge/client/building.hpp
@@ -53,7 +53,7 @@ class ClientBuildingType {
     static std::vector<ClientBuildingType> buildingTypesSingleton;
     return buildingTypesSingleton;
   }
-  
+
  private:
   QString GetFilename() const;
   QString GetFoundationFilename() const;
@@ -149,6 +149,9 @@ class ClientBuilding : public ClientObject {
     }
   }
   
+  /// The scale of the tree sprites. Starts with a value of 1 and can be changed durring a match.
+  static float TreeScale;
+
  private:
   // TODO: Allow to queue technologies as well
   std::vector<UnitType> productionQueue;

--- a/src/FreeAge/client/building.hpp
+++ b/src/FreeAge/client/building.hpp
@@ -149,7 +149,7 @@ class ClientBuilding : public ClientObject {
     }
   }
   
-  /// The scale of the tree sprites. Starts with a value of 1 and can be changed durring a match.
+  /// The scale of the tree sprites. Starts with a value of 1 and can be changed during a match.
   static float TreeScale;
 
  private:

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -4282,6 +4282,8 @@ void RenderWindow::keyPressEvent(QKeyEvent* event) {
     return;
   }
   
+  bool shift = event->modifiers() & Qt::ShiftModifier;
+
   if (event->key() == Qt::Key_Right) {
     scrollRightPressed = true;
     scrollRightPressTime = Clock::now();
@@ -4300,6 +4302,13 @@ void RenderWindow::keyPressEvent(QKeyEvent* event) {
     }
   } else if (event->key() == Qt::Key_H) {
     JumpToNextTownCenter();
+  } else if (event->key() == Qt::Key_J) { // TODO: change key
+    // TODO: get values from user settings
+    float mediumValue = .35f;
+    float smallValue = .2f;
+    float value = shift ? smallValue : mediumValue;
+    ClientBuilding::TreeScale = ClientBuilding::TreeScale != value ? value : 1.f;
+    // TODO: animate ??
   } else if (event->key() == Qt::Key_Space) {
     spaceHeld = true;
   } else if (event->key() >= Qt::Key_0 && event->key() <= Qt::Key_9) {

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3629,6 +3629,16 @@ void RenderWindow::paintGL() {
       scrollProjectedCoordOffset.setY(0);
     }
   }
+
+  if (treeScale != ClientBuilding::TreeScale) {
+    float d = treeScale - ClientBuilding::TreeScale;
+    if (fabs(d) < 0.001f) {
+      ClientBuilding::TreeScale = treeScale;
+    } else {
+      // TODO: change with proper frame rate idependant interpolation
+      ClientBuilding::TreeScale += d * .1f;
+    }
+  }
   
   // Center the view on the selection if the space key is held.
   if (spaceHeld) {
@@ -4303,12 +4313,14 @@ void RenderWindow::keyPressEvent(QKeyEvent* event) {
   } else if (event->key() == Qt::Key_H) {
     JumpToNextTownCenter();
   } else if (event->key() == Qt::Key_J) { // TODO: change key
-    // TODO: get values from user settings
-    float mediumValue = .35f;
-    float smallValue = .2f;
+    bool animate = true; // TODO: user setting
+    float mediumValue = .35f; // TODO: user setting
+    float smallValue = .2f; // TODO: user setting
     float value = shift ? smallValue : mediumValue;
-    ClientBuilding::TreeScale = ClientBuilding::TreeScale != value ? value : 1.f;
-    // TODO: animate ??
+    treeScale = treeScale != value ? value : 1.f;
+    if (!animate) {
+      ClientBuilding::TreeScale = treeScale;
+    }
   } else if (event->key() == Qt::Key_Space) {
     spaceHeld = true;
   } else if (event->key() >= Qt::Key_0 && event->key() <= Qt::Key_9) {

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3631,12 +3631,13 @@ void RenderWindow::paintGL() {
   }
 
   if (treeScale != ClientBuilding::TreeScale) {
-    float d = treeScale - ClientBuilding::TreeScale;
-    if (fabs(d) < 0.001f) {
+    constexpr float treeScaleUpdateRate = 0.85f;
+
+    if (fabs(treeScale - ClientBuilding::TreeScale) < 0.001f) {
       ClientBuilding::TreeScale = treeScale;
     } else {
-      // TODO: change with proper frame rate idependant interpolation
-      ClientBuilding::TreeScale += d * .1f;
+      float factor = std::pow(treeScaleUpdateRate, 60 * secondsSinceLastFrame);
+      ClientBuilding::TreeScale = (1.f - factor) * treeScale + factor * ClientBuilding::TreeScale;
     }
   }
   

--- a/src/FreeAge/client/render_window.hpp
+++ b/src/FreeAge/client/render_window.hpp
@@ -282,6 +282,9 @@ class RenderWindow : public QOpenGLWindow {
   
   /// Whether to use smooth zooming or step-wise zooming. TODO: Make configurable.
   bool smoothZooming = true;
+
+  /// The target value for the ClientBuilding::TreeScale to interpolate over.
+  float treeScale = 1;
   
   /// Game start time.
   TimePoint renderStartTime;


### PR DESCRIPTION
I like the small trees mod, and many people think that is mandatory, however I don't like how the game looks. The solution? toggle-able small trees!

Scenario: Villager -> Select LumberCamp -> Toogle small trees -> Place LumberCamp -> Toogle small trees.

Now you can press: _(J is a placeholder)_
- **J** : toggle small trees
- **Shift+J**: toggle tiny trees

Also I added a small hacky interpolation animation like thing, just because it looks awesome.

And of course all of these could be configured in the user settings.

_The same approach could be used for the grid mod..._
