### PR TITLE
Damage types, armor and damage calculation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ set_target_properties(gtest gtest_main PROPERTIES FOLDER "third_party")
 # FreeAge base library, used by both the application and the test
 add_library(FreeAgeLib
   src/FreeAge/common/building_types.cpp
+  src/FreeAge/common/damage.cpp
   src/FreeAge/common/messages.cpp
   src/FreeAge/common/player.cpp
   src/FreeAge/common/timing.cpp

--- a/src/FreeAge/common/building_types.cpp
+++ b/src/FreeAge/common/building_types.cpp
@@ -199,6 +199,15 @@ Armor GetBuildingArmor(BuildingType type) {
     armor.SetValue(DamageType::StandardBuilding, 0);
     return armor;
   };
+  auto buildingWallArmor = [](int melee , int pierce) {
+    Armor armor = GetDefaultArmor(false);
+    armor.SetValue(DamageType::Melee, melee);
+    armor.SetValue(DamageType::Pierce, pierce);
+    armor.SetValue(DamageType::Building, 0);
+    armor.SetValue(DamageType::StandardBuilding, 0);
+    armor.SetValue(DamageType::WallGate, 0);
+    return armor;
+  };
 
   switch (type) {
   case BuildingType::TownCenter: return buildingArmor(3, 5);
@@ -215,8 +224,8 @@ Armor GetBuildingArmor(BuildingType type) {
   
   case BuildingType::Barracks: return buildingArmor(0, 7);
   case BuildingType::Outpost: return buildingArmor(0, 0);
-  case BuildingType::PalisadeWall: return buildingArmor(2, 5);  // TODO: 0 during construction?
-  case BuildingType::PalisadeGate: return buildingArmor(2, 2);  // TODO: 0 during construction?
+  case BuildingType::PalisadeWall: return buildingWallArmor(2, 5);  // TODO: 0 during construction?
+  case BuildingType::PalisadeGate: return buildingWallArmor(2, 2);  // TODO: 0 during construction?
   
   case BuildingType::TreeOak: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TreeOak"; return GetDefaultArmor(false);
   case BuildingType::ForageBush: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::ForageBush"; return GetDefaultArmor(false);

--- a/src/FreeAge/common/building_types.cpp
+++ b/src/FreeAge/common/building_types.cpp
@@ -227,7 +227,11 @@ Armor GetBuildingArmor(BuildingType type) {
   case BuildingType::PalisadeWall: return buildingWallArmor(2, 5);  // TODO: 0 during construction?
   case BuildingType::PalisadeGate: return buildingWallArmor(2, 2);  // TODO: 0 during construction?
   
-  case BuildingType::TreeOak: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TreeOak"; return GetDefaultArmor(false);
+  case BuildingType::TreeOak: { // assumption
+    Armor armor = GetDefaultArmor(false);
+    armor.SetValue(DamageType::Tree, 0);
+    return armor;
+  };
   case BuildingType::ForageBush: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::ForageBush"; return GetDefaultArmor(false);
   case BuildingType::GoldMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::GoldMine"; return GetDefaultArmor(false);
   case BuildingType::StoneMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::StoneMine"; return GetDefaultArmor(false);

--- a/src/FreeAge/common/building_types.cpp
+++ b/src/FreeAge/common/building_types.cpp
@@ -190,32 +190,41 @@ u32 GetBuildingMaxHP(BuildingType type) {
   return 0;
 }
 
-u32 GetBuildingMeleeArmor(BuildingType type) {
+Armor GetBuildingArmor(BuildingType type) {
+  auto buildingArmor = [](int melee , int pierce) {
+    Armor armor = GetDefaultArmor(false);
+    armor.SetValue(DamageType::Melee, melee);
+    armor.SetValue(DamageType::Pierce, pierce);
+    armor.SetValue(DamageType::Building, 0);
+    armor.SetValue(DamageType::StandardBuilding, 0);
+    return armor;
+  };
+
   switch (type) {
-  case BuildingType::TownCenter: return 3;
-  case BuildingType::TownCenterBack: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterBack"; return 0;
-  case BuildingType::TownCenterCenter: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterCenter"; return 0;
-  case BuildingType::TownCenterFront: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterFront"; return 0;
-  case BuildingType::TownCenterMain: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterMain"; return 0;
-  case BuildingType::House: return 0;
+  case BuildingType::TownCenter: return buildingArmor(3, 5);
+  case BuildingType::TownCenterBack: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterBack"; return GetDefaultArmor(false);
+  case BuildingType::TownCenterCenter: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterCenter"; return GetDefaultArmor(false);
+  case BuildingType::TownCenterFront: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterFront"; return GetDefaultArmor(false);
+  case BuildingType::TownCenterMain: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterMain"; return GetDefaultArmor(false);
+  case BuildingType::House: return buildingArmor(0, 7);
   
-  case BuildingType::Mill: return 0;
-  case BuildingType::MiningCamp: return 0;
-  case BuildingType::LumberCamp: return 0;
-  case BuildingType::Dock: return 0;
+  case BuildingType::Mill: return buildingArmor(0, 7);
+  case BuildingType::MiningCamp: return buildingArmor(0, 7);
+  case BuildingType::LumberCamp: return buildingArmor(0, 7);
+  case BuildingType::Dock: return buildingArmor(0, 7);
   
-  case BuildingType::Barracks: return 0;
-  case BuildingType::Outpost: return 0;
-  case BuildingType::PalisadeWall: return 2;  // TODO: 0 during construction?
-  case BuildingType::PalisadeGate: return 2;  // TODO: 0 during construction?
+  case BuildingType::Barracks: return buildingArmor(0, 7);
+  case BuildingType::Outpost: return buildingArmor(0, 0);
+  case BuildingType::PalisadeWall: return buildingArmor(2, 5);  // TODO: 0 during construction?
+  case BuildingType::PalisadeGate: return buildingArmor(2, 2);  // TODO: 0 during construction?
   
-  case BuildingType::TreeOak: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TreeOak"; return 0;
-  case BuildingType::ForageBush: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::ForageBush"; return 0;
-  case BuildingType::GoldMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::GoldMine"; return 0;
-  case BuildingType::StoneMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::StoneMine"; return 0;
-  case BuildingType::NumBuildings: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::NumBuildings"; return 0;
+  case BuildingType::TreeOak: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TreeOak"; return GetDefaultArmor(false);
+  case BuildingType::ForageBush: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::ForageBush"; return GetDefaultArmor(false);
+  case BuildingType::GoldMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::GoldMine"; return GetDefaultArmor(false);
+  case BuildingType::StoneMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::StoneMine"; return GetDefaultArmor(false);
+  case BuildingType::NumBuildings: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::NumBuildings"; return GetDefaultArmor(false);
   }
-  return 0;
+  return GetDefaultArmor(false);
 }
 
 int GetBuildingMaxInstances(BuildingType type) {

--- a/src/FreeAge/common/building_types.cpp
+++ b/src/FreeAge/common/building_types.cpp
@@ -192,7 +192,7 @@ u32 GetBuildingMaxHP(BuildingType type) {
 
 Armor GetBuildingArmor(BuildingType type) {
   auto buildingArmor = [](int melee , int pierce) {
-    Armor armor = GetDefaultArmor(false);
+    Armor armor = GetBuildingDefaultArmor();
     armor.SetValue(DamageType::Melee, melee);
     armor.SetValue(DamageType::Pierce, pierce);
     armor.SetValue(DamageType::Building, 0);
@@ -200,7 +200,7 @@ Armor GetBuildingArmor(BuildingType type) {
     return armor;
   };
   auto buildingWallArmor = [](int melee , int pierce) {
-    Armor armor = GetDefaultArmor(false);
+    Armor armor = GetBuildingDefaultArmor();
     armor.SetValue(DamageType::Melee, melee);
     armor.SetValue(DamageType::Pierce, pierce);
     armor.SetValue(DamageType::Building, 0);
@@ -211,10 +211,10 @@ Armor GetBuildingArmor(BuildingType type) {
 
   switch (type) {
   case BuildingType::TownCenter: return buildingArmor(3, 5);
-  case BuildingType::TownCenterBack: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterBack"; return GetDefaultArmor(false);
-  case BuildingType::TownCenterCenter: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterCenter"; return GetDefaultArmor(false);
-  case BuildingType::TownCenterFront: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterFront"; return GetDefaultArmor(false);
-  case BuildingType::TownCenterMain: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterMain"; return GetDefaultArmor(false);
+  case BuildingType::TownCenterBack: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterBack"; return GetBuildingDefaultArmor();
+  case BuildingType::TownCenterCenter: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterCenter"; return GetBuildingDefaultArmor();
+  case BuildingType::TownCenterFront: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterFront"; return GetBuildingDefaultArmor();
+  case BuildingType::TownCenterMain: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::TownCenterMain"; return GetBuildingDefaultArmor();
   case BuildingType::House: return buildingArmor(0, 7);
   
   case BuildingType::Mill: return buildingArmor(0, 7);
@@ -228,16 +228,16 @@ Armor GetBuildingArmor(BuildingType type) {
   case BuildingType::PalisadeGate: return buildingWallArmor(2, 2);  // TODO: 0 during construction?
   
   case BuildingType::TreeOak: { // assumption
-    Armor armor = GetDefaultArmor(false);
+    Armor armor = GetBuildingDefaultArmor();
     armor.SetValue(DamageType::Tree, 0);
     return armor;
   };
-  case BuildingType::ForageBush: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::ForageBush"; return GetDefaultArmor(false);
-  case BuildingType::GoldMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::GoldMine"; return GetDefaultArmor(false);
-  case BuildingType::StoneMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::StoneMine"; return GetDefaultArmor(false);
-  case BuildingType::NumBuildings: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::NumBuildings"; return GetDefaultArmor(false);
+  case BuildingType::ForageBush: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::ForageBush"; return GetBuildingDefaultArmor();
+  case BuildingType::GoldMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::GoldMine"; return GetBuildingDefaultArmor();
+  case BuildingType::StoneMine: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::StoneMine"; return GetBuildingDefaultArmor();
+  case BuildingType::NumBuildings: LOG(ERROR) << "GetBuildingMeleeArmor() called on BuildingType::NumBuildings"; return GetBuildingDefaultArmor();
   }
-  return GetDefaultArmor(false);
+  return GetBuildingDefaultArmor();
 }
 
 int GetBuildingMaxInstances(BuildingType type) {

--- a/src/FreeAge/common/building_types.hpp
+++ b/src/FreeAge/common/building_types.hpp
@@ -8,6 +8,7 @@
 #include <QSize>
 #include <QString>
 
+#include "FreeAge/common/damage.hpp"
 #include "FreeAge/common/resources.hpp"
 
 /// Building types. The numbers must be sequential, starting from zero,
@@ -61,7 +62,7 @@ bool IsDropOffPointForResource(BuildingType building, ResourceType resource);
 
 /// TODO: This needs to consider the player's civilization and researched technologies
 u32 GetBuildingMaxHP(BuildingType type);
-u32 GetBuildingMeleeArmor(BuildingType type);
+Armor GetBuildingArmor(BuildingType type);
 
 /// Returns the max number of the given building type that the player can build.
 /// Returns -1 if unlimited.

--- a/src/FreeAge/common/damage.cpp
+++ b/src/FreeAge/common/damage.cpp
@@ -4,6 +4,8 @@
 
 #include "FreeAge/common/damage.hpp"
 
+#include <algorithm>
+
 inline DamageValues::DamageValues() {
   for (int i = 0; i < static_cast<int>(DamageType::NumDamageTypes); ++ i) {
     values[i] = None;

--- a/src/FreeAge/common/damage.cpp
+++ b/src/FreeAge/common/damage.cpp
@@ -3,10 +3,11 @@
 // See the COPYING file in the project root for the license text.
 
 #include "FreeAge/common/damage.hpp"
+#include "FreeAge/common/logging.hpp"
 
 #include <algorithm>
 
-inline DamageValues::DamageValues() {
+DamageValues::DamageValues() {
   for (int i = 0; i < static_cast<int>(DamageType::NumDamageTypes); ++ i) {
     values[i] = None;
   }
@@ -14,7 +15,7 @@ inline DamageValues::DamageValues() {
 
 DamageValues::DamageValues(const DamageValues& other) {
   for (int i = 0; i < static_cast<int>(DamageType::NumDamageTypes); ++ i) {
-    values[i] = other.GetValue(i);
+    values[i] = other.values[i];
   }
 }
 
@@ -34,9 +35,11 @@ void DamageValues::AddValue(DamageType damageType, i32 value) {
 Armor GetDefaultArmor(bool isUnit) {
   Armor armor;
   if (isUnit) {
+    CHECK_EQ(armor.GetValue(DamageType::Melee), Armor::None);
     armor.SetValue(DamageType::Melee, 0);
     armor.SetValue(DamageType::Pierce, 0);
     armor.SetValue(DamageType::AntiLeitis, 0);
+    CHECK_EQ(armor.GetValue(DamageType::Melee), 0);
   }
   return armor;
 }
@@ -63,5 +66,5 @@ i32 CalculateDamage(const Damage& damage, const Armor& armor, float multiplier) 
     sum += std::max(0, damageValue - armorValue);
   }
   // damage is always at least 1
-  return std::max(1, static_cast<i32>(sum * multiplier));
+  return std::max(1, static_cast<i32>(sum * multiplier + .5f));
 }

--- a/src/FreeAge/common/damage.cpp
+++ b/src/FreeAge/common/damage.cpp
@@ -1,0 +1,59 @@
+// Copyright 2020 The FreeAge authors
+// This file is part of FreeAge, licensed under the new BSD license.
+// See the COPYING file in the project root for the license text.
+
+#include "FreeAge/common/damage.hpp"
+
+inline DamageValues::DamageValues() {
+  for (int i = 0; i < static_cast<int>(DamageType::NumDamageTypes); ++ i) {
+    values[i] = None;
+  }
+}
+
+void DamageValues::AddValue(DamageType damageType, i32 value) {
+  if (value == None) {
+    return; // ignore
+  }
+  i32 baseValue = GetValue(damageType);
+  if (baseValue == None) {
+    SetValue(damageType, value);
+  } else {
+    // add values only if they are both != None
+    SetValue(damageType, baseValue + value);
+  }
+}
+
+Armor GetDefaultArmor(bool isUnit) {
+  Armor armor;
+  if (isUnit) {
+    armor.SetValue(DamageType::Melee, 0);
+    armor.SetValue(DamageType::Pierce, 0);
+    armor.SetValue(DamageType::AntiLeitis, 0);
+  }
+  return armor;
+}
+
+Damage GetDefaultDamage(bool /*isUnit*/) {
+  Damage damage;
+  return damage;
+}
+
+i32 CalculateDamage(const Damage& damage, const Armor& armor, float multiplier) {
+  i32 sum = 0;
+  for (int i = 0; i < static_cast<int>(DamageType::NumDamageTypes); ++ i) {
+    i32 armorValue = armor.GetValue(i);
+    if (armorValue == Armor::None) {
+      // the defending unit does not take damage from this damage type
+      continue;
+    }
+    i32 damageValue = damage.GetValue(i);
+    if (damageValue == Damage::None) {
+      // the attacking unit does not deal damage of this damage type
+      continue;
+    }
+    // NOTE: damageValue can be 0, armorValue can be negative
+    sum += std::max(0, damageValue - armorValue);
+  }
+  // damage is always at least 1
+  return std::max(1, static_cast<i32>(sum * multiplier));
+}

--- a/src/FreeAge/common/damage.cpp
+++ b/src/FreeAge/common/damage.cpp
@@ -12,6 +12,12 @@ inline DamageValues::DamageValues() {
   }
 }
 
+DamageValues::DamageValues(const DamageValues& other) {
+  for (int i = 0; i < static_cast<int>(DamageType::NumDamageTypes); ++ i) {
+    values[i] = other.GetValue(i);
+  }
+}
+
 void DamageValues::AddValue(DamageType damageType, i32 value) {
   if (value == None) {
     return; // ignore

--- a/src/FreeAge/common/damage.hpp
+++ b/src/FreeAge/common/damage.hpp
@@ -59,24 +59,24 @@ struct DamageValues {
 
   /// Initialize all values with None.
   /// Prefer GetDefaultArmor and GetDefaultDamage to create new objects.
-  inline DamageValues();
+  DamageValues();
 
   DamageValues(const DamageValues& other);
 
   /// Increase the value of a damage type (handling cases with values of None).
   void AddValue(DamageType damageType, i32 value);
 
-  inline void SetValue(DamageType damageType, i32 value) { values[static_cast<int>(damageType)] = value; }
+  void SetValue(DamageType damageType, i32 value) { values[static_cast<int>(damageType)] = value; }
 
-  inline i32 GetValue(DamageType damageType) const { return values[static_cast<int>(damageType)]; }
-  inline i32 GetValue(int index) const { return values[index]; }
+  i32 GetValue(DamageType damageType) const { return values[static_cast<int>(damageType)]; }
+  i32 GetValue(int index) const { return values[index]; }
 
-  inline i32 HasValue(DamageType damageType) const { return values[static_cast<int>(damageType)] != None; }
+  i32 HasValue(DamageType damageType) const { return values[static_cast<int>(damageType)] != None; }
 
   // The original gui mostly uses the Melee and Pierce values.
 
-  inline i32 melee() const { return GetValue(DamageType::Melee); }
-  inline i32 pierce() const { return GetValue(DamageType::Pierce); }
+  i32 melee() const { return GetValue(DamageType::Melee); }
+  i32 pierce() const { return GetValue(DamageType::Pierce); }
 
  private:
 
@@ -98,6 +98,11 @@ typedef DamageValues Damage;
 Armor GetDefaultArmor(bool isUnit);
 /// Returns the Damage with the default values.
 Damage GetDefaultDamage(bool isUnit);
+
+inline Armor GetUnitDefaultArmor() { return GetDefaultArmor(true); }
+inline Damage GetUnitDefaultDamage() { return GetDefaultDamage(true); }
+inline Armor GetBuildingDefaultArmor() { return GetDefaultArmor(false); }
+inline Damage GetBuildingDefaultDamage() { return GetDefaultDamage(false); }
 
 /// Returns the damage (reduction of health) that the given Damage will cause to the
 /// object with the given Armor.

--- a/src/FreeAge/common/damage.hpp
+++ b/src/FreeAge/common/damage.hpp
@@ -1,0 +1,102 @@
+// Copyright 2020 The FreeAge authors
+// This file is part of FreeAge, licensed under the new BSD license.
+// See the COPYING file in the project root for the license text.
+
+#pragma once
+
+#include <limits>
+
+#include "FreeAge/common/free_age.hpp"
+
+enum class DamageType {
+  Melee = 0,
+  Pierce,
+  // units
+  Infantry,
+  TurtleShip,
+  WarElephant,
+  Cavalry,
+  PredatorAnimals,
+  Archer,
+  Ship,
+  Ram,
+  Tree,
+  UniqueUnit,
+  SiegeWeapon,
+  GunpowderUnit,
+  Boar,
+  Monk,
+  Spearman,
+  CavalryArcher,
+  EagleWarrior,
+  Camel,
+  AntiLeitis,
+  Condottiero,
+  FishingShip,
+  Mameluke,
+  HeroKing,
+  // buildings
+  Building,
+  StoneDefense,
+  StandardBuilding,
+  WallGate,
+  Castle,
+
+  NumDamageTypes
+};
+
+/// TODO: Reorder the damage types in way that make sense and even could be used to compress
+///       the DamageValues when is send over the network or stored. Note that the original game
+///       ids are not 100% consecutive.
+
+/// A map of every DamageType to a signed integer.
+/// It can represent the damage or the armor of a unit or a building. The special value
+/// DamageValues::None is used to define that the corresponding DamageType is ignored.
+struct DamageValues {
+
+  /// Defines that the corresponding DamageType is ignored.
+  static constexpr i32 None = std::numeric_limits<i32>::min();
+
+  /// Initialize all values with None.
+  /// Prefer GetDefaultArmor and GetDefaultDamage to create new objects.
+  inline DamageValues();
+
+  /// Increase the value of a damage type (handling cases with values of None).
+  void AddValue(DamageType damageType, i32 value);
+
+  inline void SetValue(DamageType damageType, i32 value) { values[static_cast<int>(damageType)] = value; }
+
+  inline i32 GetValue(DamageType damageType) const { return values[static_cast<int>(damageType)]; }
+  inline i32 GetValue(int index) const { return values[index]; }
+
+  inline i32 HasValue(DamageType damageType) const { return values[static_cast<int>(damageType)] != None; }
+
+  // The original gui mostly uses the Melee and Pierce values.
+
+  inline i32 melee() const { return GetValue(DamageType::Melee); }
+  inline i32 pierce() const { return GetValue(DamageType::Pierce); }
+
+ private:
+
+  /// A value for each damage type.
+  /// TODO: reduce to i16 ?, max value of original game is 250
+  i32 values[static_cast<int>(DamageType::NumDamageTypes)];
+
+};
+
+/// DamageValues can be used for the damage or the armor of a unit or a building.
+/// To make the code clearer the two typedefs Damage and Armor should be used.
+
+// The armor of a unit or a building.
+typedef DamageValues Armor;
+/// The attack damage of a unit or a building.
+typedef DamageValues Damage;
+
+/// Returns the Damage with the default values.
+Armor GetDefaultArmor(bool isUnit);
+/// Returns the Damage with the default values.
+Damage GetDefaultDamage(bool isUnit);
+
+/// Returns the damage (reduction of health) that the given Damage will cause to the
+/// object with the given Armor.
+i32 CalculateDamage(const Damage& damage, const Armor& armor, float multiplier = 1);

--- a/src/FreeAge/common/damage.hpp
+++ b/src/FreeAge/common/damage.hpp
@@ -61,6 +61,8 @@ struct DamageValues {
   /// Prefer GetDefaultArmor and GetDefaultDamage to create new objects.
   inline DamageValues();
 
+  DamageValues(const DamageValues& other);
+
   /// Increase the value of a damage type (handling cases with values of None).
   void AddValue(DamageType damageType, i32 value);
 

--- a/src/FreeAge/common/unit_types.cpp
+++ b/src/FreeAge/common/unit_types.cpp
@@ -144,44 +144,63 @@ u32 GetUnitMaxHP(UnitType type) {
   return 0;
 }
 
-u32 GetUnitMeleeAttack(UnitType type) {
+Damage GetUnitDamage(UnitType type) {
   // TODO: Load this from some data file
   
   if (IsVillager(type)) {
-    return 3;
+    Damage damage = GetDefaultDamage(true);
+    damage.SetValue(DamageType::Melee, 3);
+    damage.SetValue(DamageType::StoneDefense, 6);
+    damage.SetValue(DamageType::Building, 3);
+    return damage;
   }
   
   switch (type) {
-  case UnitType::Militia:
-    return 4;
-  case UnitType::Scout:
-    return 3;
+  case UnitType::Militia: {
+    Damage damage = GetDefaultDamage(true);
+    damage.SetValue(DamageType::Melee, 4);
+    return damage;
+  }
+  case UnitType::Scout: {
+    Damage damage = GetDefaultDamage(true);
+    damage.SetValue(DamageType::Melee, 3);
+    damage.SetValue(DamageType::Monk, 6);
+    return damage;
+  }
   default:
     LOG(ERROR) << "Function called on unsupported type: " << static_cast<int>(type);
     break;
   }
   
-  return 0;
+  return GetDefaultDamage(true);
 }
 
-u32 GetUnitMeleeArmor(UnitType type) {
+Armor GetUnitArmor(UnitType type) {
   // TODO: Load this from some data file
   
   if (IsVillager(type)) {
-    return 0;
+    return GetDefaultArmor(true);
   }
   
   switch (type) {
-  case UnitType::Militia:
-    return 0;
-  case UnitType::Scout:
-    return 0;
+  case UnitType::Militia: {
+    Armor armor = GetDefaultArmor(true);
+    armor.SetValue(DamageType::Pierce, 1);
+    armor.SetValue(DamageType::Infantry, 0);
+    return armor;
+  }
+  case UnitType::Scout: {
+    Armor armor = GetDefaultArmor(true);
+    armor.SetValue(DamageType::Pierce, 2);
+    armor.SetValue(DamageType::Cavalry, 0);
+    return armor;
+  }
   default:
     LOG(ERROR) << "Function called on unsupported type: " << static_cast<int>(type);
     break;
   }
   
-  return 0;
+  return GetDefaultArmor(true);
 }
 
 float GetUnitLineOfSight(UnitType type) {

--- a/src/FreeAge/common/unit_types.cpp
+++ b/src/FreeAge/common/unit_types.cpp
@@ -152,6 +152,7 @@ Damage GetUnitDamage(UnitType type) {
     damage.SetValue(DamageType::Melee, 3);
     damage.SetValue(DamageType::StoneDefense, 6);
     damage.SetValue(DamageType::Building, 3);
+    damage.SetValue(DamageType::Tree, 15); // assumption
     return damage;
   }
   

--- a/src/FreeAge/common/unit_types.cpp
+++ b/src/FreeAge/common/unit_types.cpp
@@ -148,7 +148,7 @@ Damage GetUnitDamage(UnitType type) {
   // TODO: Load this from some data file
   
   if (IsVillager(type)) {
-    Damage damage = GetDefaultDamage(true);
+    Damage damage = GetUnitDefaultDamage();
     damage.SetValue(DamageType::Melee, 3);
     damage.SetValue(DamageType::StoneDefense, 6);
     damage.SetValue(DamageType::Building, 3);
@@ -158,12 +158,12 @@ Damage GetUnitDamage(UnitType type) {
   
   switch (type) {
   case UnitType::Militia: {
-    Damage damage = GetDefaultDamage(true);
+    Damage damage = GetUnitDefaultDamage();
     damage.SetValue(DamageType::Melee, 4);
     return damage;
   }
   case UnitType::Scout: {
-    Damage damage = GetDefaultDamage(true);
+    Damage damage = GetUnitDefaultDamage();
     damage.SetValue(DamageType::Melee, 3);
     damage.SetValue(DamageType::Monk, 6);
     return damage;
@@ -173,25 +173,25 @@ Damage GetUnitDamage(UnitType type) {
     break;
   }
   
-  return GetDefaultDamage(true);
+  return GetUnitDefaultDamage();
 }
 
 Armor GetUnitArmor(UnitType type) {
   // TODO: Load this from some data file
   
   if (IsVillager(type)) {
-    return GetDefaultArmor(true);
+    return GetUnitDefaultArmor();
   }
   
   switch (type) {
   case UnitType::Militia: {
-    Armor armor = GetDefaultArmor(true);
+    Armor armor = GetUnitDefaultArmor();
     armor.SetValue(DamageType::Pierce, 1);
     armor.SetValue(DamageType::Infantry, 0);
     return armor;
   }
   case UnitType::Scout: {
-    Armor armor = GetDefaultArmor(true);
+    Armor armor = GetUnitDefaultArmor();
     armor.SetValue(DamageType::Pierce, 2);
     armor.SetValue(DamageType::Cavalry, 0);
     return armor;
@@ -201,7 +201,7 @@ Armor GetUnitArmor(UnitType type) {
     break;
   }
   
-  return GetDefaultArmor(true);
+  return GetUnitDefaultArmor();
 }
 
 float GetUnitLineOfSight(UnitType type) {

--- a/src/FreeAge/common/unit_types.hpp
+++ b/src/FreeAge/common/unit_types.hpp
@@ -6,6 +6,7 @@
 
 #include <QString>
 
+#include "FreeAge/common/damage.hpp"
 #include "FreeAge/common/resources.hpp"
 
 /// Unit types. The numbers must be sequential, starting from zero,
@@ -83,7 +84,7 @@ int GetUnitAttackFrames(UnitType type);
 
 /// TODO: This needs to consider the player's civilization and researched technologies
 u32 GetUnitMaxHP(UnitType type);
-u32 GetUnitMeleeAttack(UnitType type);
-u32 GetUnitMeleeArmor(UnitType type);
+Damage GetUnitDamage(UnitType type); // TODO: replace with GetAttack
+Armor GetUnitArmor(UnitType type);
 
 float GetUnitLineOfSight(UnitType type);

--- a/src/FreeAge/common/unit_types.hpp
+++ b/src/FreeAge/common/unit_types.hpp
@@ -84,7 +84,7 @@ int GetUnitAttackFrames(UnitType type);
 
 /// TODO: This needs to consider the player's civilization and researched technologies
 u32 GetUnitMaxHP(UnitType type);
-Damage GetUnitDamage(UnitType type); // TODO: replace with GetAttack
+Damage GetUnitDamage(UnitType type);
 Armor GetUnitArmor(UnitType type);
 
 float GetUnitLineOfSight(UnitType type);

--- a/src/FreeAge/server/game.cpp
+++ b/src/FreeAge/server/game.cpp
@@ -1307,24 +1307,22 @@ bool Game::SimulateMeleeAttack(u32 /*unitId*/, ServerUnit* unit, u32 targetId, S
       timeSinceActionStart - stepLengthInSeconds < attackDamageTime &&
       target != nullptr) {
     // Compute the attack damage.
-    int meleeArmor;
+    // TODO: Elevation multiplier 5/4 or 3/4
+    float multiplier = 1;
+    int damage;
     if (target->isUnit()) {
-      meleeArmor = GetUnitMeleeArmor(AsUnit(target)->GetType());
+      damage = CalculateDamage(GetUnitDamage(unit->GetType()),
+          GetUnitArmor(AsUnit(target)->GetType()), multiplier);
     } else {
       CHECK(target->isBuilding());
-      meleeArmor = GetBuildingMeleeArmor(AsBuilding(target)->GetType());
+      damage = CalculateDamage(GetUnitDamage(unit->GetType()),
+          GetBuildingArmor(AsBuilding(target)->GetType()), multiplier);
     }
-    int meleeDamage = std::max(0, static_cast<int>(GetUnitMeleeAttack(unit->GetType())) - meleeArmor);
-    
-    // TODO: Pierce damage
-    // TODO: Damage bonuses
-    // TODO: Elevation multiplier 5/4 or 3/4
-    
-    int totalDamage = std::max(1, meleeDamage);
+    CHECK(damage >= 1);
     
     // Do the attack damage.
     float oldHP = target->GetHPInternalFloat();
-    float hp = target->GetHPInternalFloat() - totalDamage;
+    float hp = target->GetHPInternalFloat() - damage;
     if (hp > 0.5f) {
       target->SetHP(hp);
       

--- a/src/FreeAge/test/test.cpp
+++ b/src/FreeAge/test/test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include <QApplication>
 
+#include "FreeAge/common/damage.hpp"
 #include "FreeAge/common/logging.hpp"
 #include "FreeAge/common/player.hpp"
 #include "FreeAge/client/map.hpp"
@@ -111,5 +112,56 @@ TEST(PlayerStats, Operations) {
   EXPECT_EQ(stats.GetPopulationCount(), 1);
   EXPECT_EQ(stats.GetBuildingTypeCount(BuildingType::Barracks), 0);
   EXPECT_TRUE(stats.GetBuildingTypeExisted(BuildingType::Barracks));
+
+}
+
+TEST(Damage, DamageValues) {
+  LOG(INFO) << "sizeof(DamageValues) = " << sizeof(DamageValues);
+
+  Armor armor = GetDefaultArmor(true);
+  Damage damage = GetDefaultDamage(false);
+
+  EXPECT_EQ(armor.melee(), 0);
+  EXPECT_EQ(damage.melee(), Damage::None);
+  EXPECT_EQ(damage.GetValue(DamageType::Building), Damage::None);
+
+  armor.AddValue(DamageType::Melee, 1);
+  damage.AddValue(DamageType::Melee, 1);
+
+  EXPECT_EQ(armor.GetValue(DamageType::Melee), 1);
+  EXPECT_EQ(damage.GetValue(DamageType::Melee), 1);
+
+}
+
+TEST(Damage, CalculateDamage) {
+
+  Damage archerDamage = GetDefaultDamage(true);
+  archerDamage.SetValue(DamageType::Pierce, 4);
+  archerDamage.SetValue(DamageType::Spearman, 3);
+
+  Armor villagerArmor = GetDefaultArmor(true);
+
+  Armor spearmanArmor = GetDefaultArmor(true);
+  spearmanArmor.SetValue(DamageType::Melee, 0);
+  spearmanArmor.SetValue(DamageType::Pierce, 0);
+  spearmanArmor.SetValue(DamageType::Infantry, 0);
+  spearmanArmor.SetValue(DamageType::Spearman, 0);
+
+  EXPECT_EQ(CalculateDamage(archerDamage, villagerArmor), 4);
+  EXPECT_EQ(CalculateDamage(archerDamage, spearmanArmor), 7);
+
+  villagerArmor.AddValue(DamageType::Pierce, 2);
+  spearmanArmor.AddValue(DamageType::Pierce, 1);
+
+  EXPECT_EQ(CalculateDamage(archerDamage, villagerArmor), 2);
+  EXPECT_EQ(CalculateDamage(archerDamage, spearmanArmor), 6);
+
+  Armor ramArmor = GetDefaultArmor(true);
+  ramArmor.SetValue(DamageType::Melee, -3);
+
+  Damage villagerDamage = GetDefaultDamage(true);
+  villagerDamage.SetValue(DamageType::Melee, 3);
+
+  EXPECT_EQ(CalculateDamage(villagerDamage, ramArmor), 6);
 
 }

--- a/src/FreeAge/test/test.cpp
+++ b/src/FreeAge/test/test.cpp
@@ -165,3 +165,22 @@ TEST(Damage, CalculateDamage) {
   EXPECT_EQ(CalculateDamage(villagerDamage, ramArmor), 6);
 
 }
+
+TEST(GameLogic, VillagerVsTree) {
+  // Test the number of hits needed to chop a tree.
+
+  Damage villagerDamage = GetUnitDamage(UnitType::MaleVillagerLumberjack);
+  Damage treeArmor = GetBuildingArmor(BuildingType::TreeOak);
+
+  // kill in two hits
+  EXPECT_EQ(CalculateDamage(villagerDamage, treeArmor), 15);
+
+  // apply the Sappers technology
+  villagerDamage.AddValue(DamageType::Building, 15);
+  villagerDamage.AddValue(DamageType::StoneDefense, 15);
+  villagerDamage.AddValue(DamageType::Tree, 5); // assumption
+
+  // kill in one hit
+  EXPECT_GE(CalculateDamage(villagerDamage, treeArmor), 20);
+
+}

--- a/src/FreeAge/test/test.cpp
+++ b/src/FreeAge/test/test.cpp
@@ -118,10 +118,11 @@ TEST(PlayerStats, Operations) {
 TEST(Damage, DamageValues) {
   LOG(INFO) << "sizeof(DamageValues) = " << sizeof(DamageValues);
 
-  Armor armor = GetDefaultArmor(true);
-  Damage damage = GetDefaultDamage(false);
+  Armor armor = GetUnitDefaultArmor();
+  Damage damage = GetBuildingDefaultDamage();
 
   EXPECT_EQ(armor.melee(), 0);
+  EXPECT_EQ(armor.pierce(), 0);
   EXPECT_EQ(damage.melee(), Damage::None);
   EXPECT_EQ(damage.GetValue(DamageType::Building), Damage::None);
 
@@ -135,13 +136,13 @@ TEST(Damage, DamageValues) {
 
 TEST(Damage, CalculateDamage) {
 
-  Damage archerDamage = GetDefaultDamage(true);
+  Damage archerDamage = GetUnitDefaultDamage();
   archerDamage.SetValue(DamageType::Pierce, 4);
   archerDamage.SetValue(DamageType::Spearman, 3);
 
-  Armor villagerArmor = GetDefaultArmor(true);
+  Armor villagerArmor = GetUnitDefaultArmor();
 
-  Armor spearmanArmor = GetDefaultArmor(true);
+  Armor spearmanArmor = GetUnitDefaultArmor();
   spearmanArmor.SetValue(DamageType::Melee, 0);
   spearmanArmor.SetValue(DamageType::Pierce, 0);
   spearmanArmor.SetValue(DamageType::Infantry, 0);
@@ -156,10 +157,10 @@ TEST(Damage, CalculateDamage) {
   EXPECT_EQ(CalculateDamage(archerDamage, villagerArmor), 2);
   EXPECT_EQ(CalculateDamage(archerDamage, spearmanArmor), 6);
 
-  Armor ramArmor = GetDefaultArmor(true);
+  Armor ramArmor = GetUnitDefaultArmor();
   ramArmor.SetValue(DamageType::Melee, -3);
 
-  Damage villagerDamage = GetDefaultDamage(true);
+  Damage villagerDamage = GetUnitDefaultDamage();
   villagerDamage.SetValue(DamageType::Melee, 3);
 
   EXPECT_EQ(CalculateDamage(villagerDamage, ramArmor), 6);


### PR DESCRIPTION
- **DamageType**: enum of all the "damage types" / "armor classes"
- **DamageValues**: map of DamageType to signed ints
  - Special int value **DamageValues::None** = ignore the corresponding damage type
- **Damage** and **Armor**: typdefs of DamageValues for readable code.
- **CalculateDamage**: calculate the health reduction based on a given Damage and Armor

Melee and Pierce damage are just a DamageType, no special handling.

_(I had implemented this once before...)_

I don't know how are you planning to do unit/building type modifications from tech and civ bonuses, but this implementation could work both like immutable and/or mutable.

Waiting on feedback :)