### PR TITLE
Garrison

### DIFF
--- a/src/FreeAge/client/command_button.cpp
+++ b/src/FreeAge/client/command_button.cpp
@@ -54,40 +54,6 @@ void CommandButton::SetAction(ActionType actionType, const Texture* texture, Qt:
   this->texture = texture;
 }
 
-CommandButton::State CommandButton::GetState(GameController* gameController) const {
-
-  // NOTE: Checks must follow an order of importance. For example the CannotAfford is less
-  // important than MaxLimitReached because if the max limit has been reached, if it can be
-  // affored or not is irrelevant.
-
-  if (GetType() == CommandButton::Type::ProduceUnit) {
-    if (!gameController->GetLatestKnownResourceAmount().CanAfford(
-            GetUnitCost(GetUnitProductionType()))) {
-      return State::CannotAfford;
-    }
-
-    // TODO: return State::Locked, if the unit is not unlocked yet
-
-  } else if (GetType() == CommandButton::Type::ConstructBuilding) {
-    BuildingType buildingType = GetBuildingConstructionType();
-
-    // Check for the max limit
-    int max = GetBuildingMaxInstances(buildingType);
-    if (max != -1 && gameController->GetBuildingTypeCount(buildingType) >= max) {
-      return State::MaxLimitReached;
-    }
-
-    // TODO: return State::Locked, if the unit is not unlocked yet
-
-    // Can afford must be the last check (less important than all the other checks)
-    if (!gameController->GetLatestKnownResourceAmount().CanAfford(GetBuildingCost(buildingType))) {
-      return State::CannotAfford;
-    }
-  }
-
-  return State::Valid;
-}
-
 void CommandButton::Render(
     float x, float y, float size, float iconInset,
     const Texture& iconOverlayNormalTexture,

--- a/src/FreeAge/client/command_button.hpp
+++ b/src/FreeAge/client/command_button.hpp
@@ -29,7 +29,6 @@ class CommandButton {
     BuildMilitaryBuilding,
     ToggleBuildingsCategory,
     Garrison,
-    // Ungarrison, // TODO: implement
     UngarrisonAll,
     Quit
   };

--- a/src/FreeAge/client/command_button.hpp
+++ b/src/FreeAge/client/command_button.hpp
@@ -25,9 +25,12 @@ class CommandButton {
   };
   
   enum class ActionType {
+    // TODO (maanoo): add a None for fast actiontype checks without the need for the type check
     BuildEconomyBuilding,
     BuildMilitaryBuilding,
     ToggleBuildingsCategory,
+    Garrison, // TODO (maanoo): move to type ?
+    UngarrisonAll,
     Quit
   };
 
@@ -37,6 +40,8 @@ class CommandButton {
   enum class State {
     /// Valid and visible
     Valid = 0,
+    /// Invalid and not visible (eg, ungarrison empty building)
+    Invalid, 
     /// Cannot be affored by the player, visible but disabled.
     CannotAfford,
     /// Max limit reached, not visible. (currently only the TownCenter can have this state)
@@ -66,8 +71,6 @@ class CommandButton {
   
   void SetAction(ActionType actionType, const Texture* texture, Qt::Key hotkey = Qt::Key_unknown);
   
-  State GetState(GameController* gameController) const;
-
   void Render(
       float x, float y, float size, float iconInset,
       const Texture& iconOverlayNormalTexture,

--- a/src/FreeAge/client/command_button.hpp
+++ b/src/FreeAge/client/command_button.hpp
@@ -30,6 +30,7 @@ class CommandButton {
     BuildMilitaryBuilding,
     ToggleBuildingsCategory,
     Garrison, // TODO (maanoo): move to type ?
+    // Ungarrison, // TODO: implement
     UngarrisonAll,
     Quit
   };

--- a/src/FreeAge/client/command_button.hpp
+++ b/src/FreeAge/client/command_button.hpp
@@ -25,11 +25,10 @@ class CommandButton {
   };
   
   enum class ActionType {
-    // TODO (maanoo): add a None for fast actiontype checks without the need for the type check
     BuildEconomyBuilding,
     BuildMilitaryBuilding,
     ToggleBuildingsCategory,
-    Garrison, // TODO (maanoo): move to type ?
+    Garrison,
     // Ungarrison, // TODO: implement
     UngarrisonAll,
     Quit

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -438,8 +438,11 @@ void GameController::GarrisonUnit(ClientUnit* unit, ClientObject* targetObject, 
     unit->UpdateFieldOfView(map.get(), 1);
   }
   
-  // TODO: if relic, keep track of number of relics in PlayerStats
-  // TODO: rest of gamelogic #stats
+  // Garrison related missing features from client and server:
+  // TODO: If relic, keep track of number of relics in PlayerStats #relics
+  // TODO: Bonus attack to some buildings (possibly not here)
+  // TODO: Bonus speed to some units (possibly not here)
+  // TODO: Heal garrisoned units (not here, in the simulation)
 }
 
 void GameController::HandleGameStepTimeMessage(const QByteArray& data) {

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -436,7 +436,8 @@ void GameController::GarrisonUnit(u32 unitId, ClientUnit* unit, u32 targetObject
     unit->SetGarrisonedInsideObject(kInvalidObjectId);
   }
   
-  // TODO (maanoo): gamelogic
+  // TODO: if relic, keep track of number of relics in PlayerStats
+  // TODO: rest of gamelogic #stats
 }
 
 void GameController::HandleGameStepTimeMessage(const QByteArray& data) {

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -398,7 +398,7 @@ void GameController::HandleUnitMovementMessage(const QByteArray& data) {
 }
 
 void GameController::HandleUnitGarrisonMessage(const QByteArray& data) {
-  if (data.size() < 4) {
+  if (data.size() < 8) {
     LOG(ERROR) << "Received a too short UnitGarrison message";
     return;
   }
@@ -428,6 +428,7 @@ void GameController::HandleUnitGarrisonMessage(const QByteArray& data) {
 
 void GameController::GarrisonUnit(ClientUnit* unit, ClientObject* targetObject, bool enter) {
   if (enter) {
+    unit->SetMovementSegment(currentGameStepServerTime, unit->GetMapCoord(), QPointF(0, 0), UnitAction::Idle, map.get(), match.get());
     unit->UpdateFieldOfView(map.get(), -1);
     targetObject->GarrisonUnit(unit);
     unit->SetGarrisonedInsideObject(targetObject);

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -423,20 +423,25 @@ void GameController::HandleUnitGarrisonMessage(const QByteArray& data) {
   }
 
   ClientUnit* unit = AsUnit(unitIt->second);
-  GarrisonUnit(unit, targetObjectIt->second, !unit->IsGarrisoned());
+  ChangeUnitGarrisonStatus(unit, targetObjectIt->second, !unit->IsGarrisoned());
 }
 
-void GameController::GarrisonUnit(ClientUnit* unit, ClientObject* targetObject, bool enter) {
+void GameController::ChangeUnitGarrisonStatus(ClientUnit* unit, ClientObject* targetObject, bool enter) {
+  // NOTE: the unit is ca be the current player's or not
   if (enter) {
     unit->SetMovementSegment(currentGameStepServerTime, unit->GetMapCoord(), QPointF(0, 0), UnitAction::Idle, map.get(), match.get());
-    unit->UpdateFieldOfView(map.get(), -1);
+    if (match->GetPlayerIndex() == unit->GetPlayerIndex()) {
+      unit->UpdateFieldOfView(map.get(), -1);
+    }
     targetObject->GarrisonUnit(unit);
     unit->SetGarrisonedInsideObject(targetObject);
   } else {
     targetObject->UngarrisonUnit(unit);
     unit->SetGarrisonedInsideObject(nullptr);
     unit->ClearOverrideDirection();
-    unit->UpdateFieldOfView(map.get(), 1);
+    if (match->GetPlayerIndex() == unit->GetPlayerIndex()) {
+      unit->UpdateFieldOfView(map.get(), 1);
+    }
   }
   
   // Garrison related missing features from client and server:

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -427,15 +427,15 @@ void GameController::HandleUnitGarrisonMessage(const QByteArray& data) {
 }
 
 void GameController::GarrisonUnit(ClientUnit* unit, ClientObject* targetObject, bool enter) {
-  // TODO: implement a way to get ID from ClientObject, then remove the ids for the arguments
   if (enter) {
+    unit->UpdateFieldOfView(map.get(), -1);
     targetObject->GarrisonUnit(unit);
     unit->SetGarrisonedInsideObject(targetObject);
-    // TODO: loose the line of sight
   } else {
     targetObject->UngarrisonUnit(unit);
     unit->SetGarrisonedInsideObject(nullptr);
     unit->ClearOverrideDirection();
+    unit->UpdateFieldOfView(map.get(), 1);
   }
   
   // TODO: if relic, keep track of number of relics in PlayerStats

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -431,11 +431,9 @@ void GameController::GarrisonUnit(u32 unitId, ClientUnit* unit, u32 targetObject
   if (enter) {
     targetObject->GarrisonUnit(unitId);
     unit->SetGarrisonedInsideObject(targetObjectId);
-    unit->UpdateFieldOfView(map.get(), -1);
   } else {
     targetObject->UngarrisonUnit(unitId);
     unit->SetGarrisonedInsideObject(kInvalidObjectId);
-    unit->UpdateFieldOfView(map.get(), 1);
   }
   
   // TODO (maanoo): gamelogic

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -435,6 +435,7 @@ void GameController::GarrisonUnit(u32 unitId, ClientUnit* unit, u32 targetObject
   } else {
     targetObject->UngarrisonUnit(unitId);
     unit->SetGarrisonedInsideObject(kInvalidObjectId);
+    unit->ClearOverrideDirection();
   }
   
   // TODO: if relic, keep track of number of relics in PlayerStats

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -431,6 +431,7 @@ void GameController::GarrisonUnit(u32 unitId, ClientUnit* unit, u32 targetObject
   if (enter) {
     targetObject->GarrisonUnit(unitId);
     unit->SetGarrisonedInsideObject(targetObjectId);
+    // TODO: loose the line of sight
   } else {
     targetObject->UngarrisonUnit(unitId);
     unit->SetGarrisonedInsideObject(kInvalidObjectId);

--- a/src/FreeAge/client/game_controller.cpp
+++ b/src/FreeAge/client/game_controller.cpp
@@ -423,18 +423,18 @@ void GameController::HandleUnitGarrisonMessage(const QByteArray& data) {
   }
 
   ClientUnit* unit = AsUnit(unitIt->second);
-  GarrisonUnit(unitId, unit, targetObjectId, targetObjectIt->second, !unit->IsGarrisoned());
+  GarrisonUnit(unit, targetObjectIt->second, !unit->IsGarrisoned());
 }
 
-void GameController::GarrisonUnit(u32 unitId, ClientUnit* unit, u32 targetObjectId, ClientObject* targetObject, bool enter) {
+void GameController::GarrisonUnit(ClientUnit* unit, ClientObject* targetObject, bool enter) {
   // TODO: implement a way to get ID from ClientObject, then remove the ids for the arguments
   if (enter) {
-    targetObject->GarrisonUnit(unitId);
-    unit->SetGarrisonedInsideObject(targetObjectId);
+    targetObject->GarrisonUnit(unit);
+    unit->SetGarrisonedInsideObject(targetObject);
     // TODO: loose the line of sight
   } else {
-    targetObject->UngarrisonUnit(unitId);
-    unit->SetGarrisonedInsideObject(kInvalidObjectId);
+    targetObject->UngarrisonUnit(unit);
+    unit->SetGarrisonedInsideObject(nullptr);
     unit->ClearOverrideDirection();
   }
   

--- a/src/FreeAge/client/game_controller.hpp
+++ b/src/FreeAge/client/game_controller.hpp
@@ -61,6 +61,7 @@ class GameController : public QObject {
   void HandleAddObjectMessage(const QByteArray& data);
   void HandleObjectDeathMessage(const QByteArray& data);
   void HandleUnitMovementMessage(const QByteArray& data);
+  void HandleUnitGarrisonMessage(const QByteArray& data);
   void HandleGameStepTimeMessage(const QByteArray& data);
   void HandleResourcesUpdateMessage(const QByteArray& data, ResourceAmount* resources);
   void HandleBuildPercentageUpdate(const QByteArray& data);
@@ -73,6 +74,7 @@ class GameController : public QObject {
   void HandleRemoveFromProductionQueueMessage(const QByteArray& data);
   void HandleSetHousedMessage(const QByteArray& data);
   
+  void GarrisonUnit(u32 unitId, ClientUnit* unit, u32 targetObjectId, ClientObject* targetObject, bool enter);
   
   std::shared_ptr<ServerConnection> connection;
   std::shared_ptr<Match> match;

--- a/src/FreeAge/client/game_controller.hpp
+++ b/src/FreeAge/client/game_controller.hpp
@@ -74,9 +74,9 @@ class GameController : public QObject {
   void HandleRemoveFromProductionQueueMessage(const QByteArray& data);
   void HandleSetHousedMessage(const QByteArray& data);
   
-  /// Change the garrison state of a unit and the targets object garrisoned units list. 
+  /// Change the garrison status of a unit and the targets object garrisoned units list. 
   /// The enter parameter is true for garrison and false for ungarrison.
-  void GarrisonUnit(ClientUnit* unit, ClientObject* targetObject, bool enter);
+  void ChangeUnitGarrisonStatus(ClientUnit* unit, ClientObject* targetObject, bool enter);
   
   std::shared_ptr<ServerConnection> connection;
   std::shared_ptr<Match> match;

--- a/src/FreeAge/client/game_controller.hpp
+++ b/src/FreeAge/client/game_controller.hpp
@@ -74,7 +74,7 @@ class GameController : public QObject {
   void HandleRemoveFromProductionQueueMessage(const QByteArray& data);
   void HandleSetHousedMessage(const QByteArray& data);
   
-  void GarrisonUnit(u32 unitId, ClientUnit* unit, u32 targetObjectId, ClientObject* targetObject, bool enter);
+  void GarrisonUnit(ClientUnit* unit, ClientObject* targetObject, bool enter);
   
   std::shared_ptr<ServerConnection> connection;
   std::shared_ptr<Match> match;

--- a/src/FreeAge/client/game_controller.hpp
+++ b/src/FreeAge/client/game_controller.hpp
@@ -74,6 +74,8 @@ class GameController : public QObject {
   void HandleRemoveFromProductionQueueMessage(const QByteArray& data);
   void HandleSetHousedMessage(const QByteArray& data);
   
+  /// Change the garrison state of a unit and the targets object garrisoned units list. 
+  /// The enter parameter is true for garrison and false for ungarrison.
   void GarrisonUnit(ClientUnit* unit, ClientObject* targetObject, bool enter);
   
   std::shared_ptr<ServerConnection> connection;

--- a/src/FreeAge/client/minimap.cpp
+++ b/src/FreeAge/client/minimap.cpp
@@ -98,7 +98,7 @@ void Minimap::Update(Map* map, const std::vector<QRgb>& playerColors, QOpenGLFun
       }
     } else if (item.second->isUnit()) {
       ClientUnit* unit = AsUnit(item.second);
-      if (map->IsUnitInFogOfWar(unit)) {
+      if (unit->IsGarrisoned() || map->IsUnitInFogOfWar(unit)) {
         continue;
       }
       

--- a/src/FreeAge/client/object.cpp
+++ b/src/FreeAge/client/object.cpp
@@ -43,12 +43,22 @@ const Texture* ClientObject::GetIconTexture() const {
   return nullptr;
 }
 
-void ClientObject::GarrisonUnit(u32 unitId) { 
-  garrisonedUnits.emplace_back(unitId);
+void ClientObject::GarrisonUnit(ClientUnit* unit) {
+  garrisonedUnits.push_back(unit);
 }
 
-void ClientObject::UngarrisonUnit(u32 unitId) {
-  garrisonedUnits.erase(std::remove(garrisonedUnits.begin(), garrisonedUnits.end(), unitId), garrisonedUnits.end());
+void ClientObject::UngarrisonUnit(ClientUnit* unit) {
+  bool found = false;
+  for (usize i = 0, size = garrisonedUnits.size(); i < size; ++ i) {
+    if (garrisonedUnits[i] == unit) {
+      garrisonedUnits.erase(garrisonedUnits.begin() + i);
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    LOG(ERROR) << "Did not find unit ID to ungarrison in garrisonedUnits";
+  }
 }
 
 InteractionType GetInteractionType(ClientObject* actor, ClientObject* target) {

--- a/src/FreeAge/client/object.cpp
+++ b/src/FreeAge/client/object.cpp
@@ -43,6 +43,14 @@ const Texture* ClientObject::GetIconTexture() const {
   return nullptr;
 }
 
+void ClientObject::GarrisonUnit(u32 unitId) { 
+  garrisonedUnits.emplace_back(unitId);
+}
+
+void ClientObject::UngarrisonUnit(u32 unitId) {
+  garrisonedUnits.erase(std::remove(garrisonedUnits.begin(), garrisonedUnits.end(), unitId), garrisonedUnits.end());
+}
+
 InteractionType GetInteractionType(ClientObject* actor, ClientObject* target) {
   // TODO: There is a copy of this function in the server code. Can we merge these copies?
   
@@ -75,6 +83,8 @@ InteractionType GetInteractionType(ClientObject* actor, ClientObject* target) {
         target->GetPlayerIndex() != kGaiaPlayerIndex) {
       return InteractionType::Attack;
     }
+
+    // TODO (maanoo): add Garrison, all cases cannot be handled here, the user has to use the garrison button in some cases
   }
   
   return InteractionType::Invalid;

--- a/src/FreeAge/client/object.cpp
+++ b/src/FreeAge/client/object.cpp
@@ -84,7 +84,8 @@ InteractionType GetInteractionType(ClientObject* actor, ClientObject* target) {
       return InteractionType::Attack;
     }
 
-    // TODO (maanoo): add Garrison, all cases cannot be handled here, the user has to use the garrison button in some cases
+    // TODO: return InteractionType::Garrison only for targets that are mainly used for garrison, like the
+    //       the transport ship and rams.
   }
   
   return InteractionType::Invalid;

--- a/src/FreeAge/client/object.cpp
+++ b/src/FreeAge/client/object.cpp
@@ -57,7 +57,7 @@ void ClientObject::UngarrisonUnit(ClientUnit* unit) {
     }
   }
   if (!found) {
-    LOG(ERROR) << "Did not find unit ID to ungarrison in garrisonedUnits";
+    LOG(ERROR) << "Did not find unit to ungarrison in garrisonedUnits";
   }
 }
 

--- a/src/FreeAge/client/object.hpp
+++ b/src/FreeAge/client/object.hpp
@@ -34,22 +34,22 @@ class ClientObject {
   inline u32 GetHP() const { return hp; }
   inline void SetHP(u32 newHP) { hp = newHP; }
   
-  // TODO (maanoo): move to cpp
-  // TODO (maanoo): doc
-  inline void GarrisonUnit(u32 unitId) { garrisonedUnits.emplace_back(unitId); }
-  inline void UngarrisonUnit(u32 unitId) { garrisonedUnits.erase(std::remove(garrisonedUnits.begin(), garrisonedUnits.end(), unitId), garrisonedUnits.end()); }
+  void GarrisonUnit(u32 unitId);
+  void UngarrisonUnit(u32 unitId);
 
+  // Returns the IDs of the units that are garrisoned.
+  inline const std::vector<u32>& GetGarrisonedUnits() const { return garrisonedUnits; }
   inline int GetGarrisonedUnitsCount() const { return garrisonedUnits.size(); }
 
  protected:
   /// Index of the player which this object belongs to.
   int playerIndex;
   
-  // TODO (maanoo): doc
-  std::vector<u32> garrisonedUnits;
-  
   /// Current hitpoints of the object.
   u32 hp;
+  
+  // The IDs of the units that are garrisoned.
+  std::vector<u32> garrisonedUnits;
   
   /// 0 for buildings, 1 for units.
   u8 objectType;

--- a/src/FreeAge/client/object.hpp
+++ b/src/FreeAge/client/object.hpp
@@ -11,6 +11,7 @@
 #include "FreeAge/client/texture.hpp"
 
 class Map;
+class ClientUnit;
 
 /// Base class for buildings and units on the client.
 class ClientObject {
@@ -34,11 +35,11 @@ class ClientObject {
   inline u32 GetHP() const { return hp; }
   inline void SetHP(u32 newHP) { hp = newHP; }
   
-  void GarrisonUnit(u32 unitId);
-  void UngarrisonUnit(u32 unitId);
+  void GarrisonUnit(ClientUnit* unit);
+  void UngarrisonUnit(ClientUnit* unit);
 
   // Returns the IDs of the units that are garrisoned.
-  inline const std::vector<u32>& GetGarrisonedUnits() const { return garrisonedUnits; }
+  inline const std::vector<ClientUnit*>& GetGarrisonedUnits() const { return garrisonedUnits; }
   inline int GetGarrisonedUnitsCount() const { return garrisonedUnits.size(); }
 
  protected:
@@ -49,7 +50,7 @@ class ClientObject {
   u32 hp;
   
   // The IDs of the units that are garrisoned.
-  std::vector<u32> garrisonedUnits;
+  std::vector<ClientUnit*> garrisonedUnits;
   
   /// 0 for buildings, 1 for units.
   u8 objectType;

--- a/src/FreeAge/client/object.hpp
+++ b/src/FreeAge/client/object.hpp
@@ -34,9 +34,19 @@ class ClientObject {
   inline u32 GetHP() const { return hp; }
   inline void SetHP(u32 newHP) { hp = newHP; }
   
+  // TODO (maanoo): move to cpp
+  // TODO (maanoo): doc
+  inline void GarrisonUnit(u32 unitId) { garrisonedUnits.emplace_back(unitId); }
+  inline void UngarrisonUnit(u32 unitId) { garrisonedUnits.erase(std::remove(garrisonedUnits.begin(), garrisonedUnits.end(), unitId), garrisonedUnits.end()); }
+
+  inline int GetGarrisonedUnitsCount() const { return garrisonedUnits.size(); }
+
  protected:
   /// Index of the player which this object belongs to.
   int playerIndex;
+  
+  // TODO (maanoo): doc
+  std::vector<u32> garrisonedUnits;
   
   /// Current hitpoints of the object.
   u32 hp;

--- a/src/FreeAge/client/object.hpp
+++ b/src/FreeAge/client/object.hpp
@@ -38,7 +38,7 @@ class ClientObject {
   void GarrisonUnit(ClientUnit* unit);
   void UngarrisonUnit(ClientUnit* unit);
 
-  // Returns the IDs of the units that are garrisoned.
+  // Returns the units that are garrisoned.
   inline const std::vector<ClientUnit*>& GetGarrisonedUnits() const { return garrisonedUnits; }
   inline int GetGarrisonedUnitsCount() const { return garrisonedUnits.size(); }
 
@@ -49,7 +49,7 @@ class ClientObject {
   /// Current hitpoints of the object.
   u32 hp;
   
-  // The IDs of the units that are garrisoned.
+  // The units that are garrisoned.
   std::vector<ClientUnit*> garrisonedUnits;
   
   /// 0 for buildings, 1 for units.

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3197,7 +3197,7 @@ void RenderWindow::PressCommandButton(CommandButton* button, bool shift) {
           }
           ClientObject* object = it->second;
           if (object->GetGarrisonedUnitsCount() > 0) {
-            // NOTE: If the ClientObject store its ID, object->GetGarrisonedUnits() could be used instead of the iteration. #ids
+            // NOTE: Could be simplified if Objects stored there ID. #ids
             std::vector<u32> unitIds;
             for (const auto& i : map->GetObjects()) {
               if (i.second->isUnit() && AsUnit(i.second)->GetGarrisonedInsideObject() == object) {
@@ -3420,7 +3420,7 @@ void RenderWindow::UngarrisonUnit(int garrisonedUnitIndex) {
     return;
   }
   ClientUnit* garrisonedUnit = objectIt->second->GetGarrisonedUnits().at(garrisonedUnitIndex);
-  // NOTE: Looking for the id of ClientUnit #ids
+  // NOTE: Could be simplified if Objects stored there ID. #ids
   for (const auto& i : map->GetObjects()) {
     if (i.second == garrisonedUnit) {
       std::vector<u32> unitIds;

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -1097,7 +1097,7 @@ void RenderWindow::RenderShadows(double displayedServerTime, QOpenGLFunctions_3_
       if (!unitTypes[static_cast<int>(unit.GetType())].GetAnimations(unit.GetCurrentAnimation()).front()->sprite.HasShadow()) {
         continue;
       }
-      if (map->IsUnitInFogOfWar(&unit)) {
+      if (unit.IsGarrisoned() || map->IsUnitInFogOfWar(&unit)) {
         continue;
       }
       
@@ -1380,7 +1380,7 @@ void RenderWindow::RenderOutlines(double displayedServerTime, QOpenGLFunctions_3
       if (!unitTypes[static_cast<int>(unit.GetType())].GetAnimations(unit.GetCurrentAnimation()).front()->sprite.HasOutline()) {
         continue;
       }
-      if (map->IsUnitInFogOfWar(&unit)) {
+      if (unit.IsGarrisoned() || map->IsUnitInFogOfWar(&unit)) {
         continue;
       }
       
@@ -1426,7 +1426,7 @@ void RenderWindow::RenderUnits(double displayedServerTime, QOpenGLFunctions_3_2_
       continue;
     }
     ClientUnit& unit = *AsUnit(object.second);
-    if (map->IsUnitInFogOfWar(&unit)) {
+    if (unit.IsGarrisoned() || map->IsUnitInFogOfWar(&unit)) {
       continue;
     }
     
@@ -2723,7 +2723,7 @@ bool RenderWindow::GetObjectToSelectAt(float x, float y, u32* objectId, std::vec
       }
     } else if (object.second->isUnit()) {
       ClientUnit& unit = *AsUnit(object.second);
-      if (map->IsUnitInFogOfWar(&unit)) {
+      if (unit.IsGarrisoned() || map->IsUnitInFogOfWar(&unit)) {
         continue;
       }
       
@@ -3509,7 +3509,7 @@ void RenderWindow::initializeGL() {
   
   isLoading = true;
   loadingStep = 0;
-  maxLoadingStep = 62;
+  maxLoadingStep = 64;
   loadingThread->start();
   
   // Create resources right now which are required for rendering the loading screen:

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3149,7 +3149,14 @@ void RenderWindow::PressCommandButton(CommandButton* button, bool shift) {
           }
           ClientObject* object = it->second;
           if (object->GetGarrisonedUnitsCount() > 0) {
-            connection->Write(CreateSetTargetWithInteractionMessage(object->GetGarrisonedUnits(), id, InteractionType::Ungarrison));
+            // NOTE: If the ClientObject store its ID, object->GetGarrisonedUnits() could be used instead of the iteration. #ids
+            std::vector<u32> unitIds;
+            for (auto& i : map->GetObjects()) {
+              if (i.second->isUnit() && AsUnit(i.second)->GetGarrisonedInsideObject() == object) {
+                unitIds.push_back(i.first);
+              }
+            }
+            connection->Write(CreateSetTargetWithInteractionMessage(unitIds, id, InteractionType::Ungarrison));
           }
         }
         break;

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -4112,10 +4112,16 @@ void RenderWindow::mousePressEvent(QMouseEvent* event) {
 
     if (activeCommandButton && activeCommandButton->GetType() == CommandButton::Type::Action) {
       if (activeCommandButton->GetActionType() == CommandButton::ActionType::Garrison) {
+        ignoreLeftMouseRelease = true;
         u32 targetObjectId;
         std::vector<u32> emptySelection;
         if (GetObjectToSelectAt(event->pos().x(), event->pos().y(), &targetObjectId, &emptySelection, false, false)) {
           ClientObject* targetObject = map->GetObjects().at(targetObjectId);
+
+          if (targetObject->GetPlayerIndex() != match->GetPlayerIndex()) {
+            // TODO: Report to the user that a unit cannot garrison in enemy object #interface-messages
+            return;
+          }
 
           // TODO: replace with the garrison capacity form the unit type stats #stats
           bool isTownCenter = targetObject->GetObjectType() == ObjectType::Building && AsBuilding(targetObject)->GetType() == BuildingType::TownCenter;
@@ -4146,7 +4152,6 @@ void RenderWindow::mousePressEvent(QMouseEvent* event) {
           }
         }
         UnsetActiveCommandButton();
-        ignoreLeftMouseRelease = true;
         return;
       }
     }

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -4127,8 +4127,15 @@ void RenderWindow::mousePressEvent(QMouseEvent* event) {
             std::vector<u32> suitableUnits;
             suitableUnits.reserve(selection.size());
             for (usize i = 0; i < selection.size(); ++ i) {
+              auto objectIt = map->GetObjects().find(selection[i]);
+              if (objectIt == map->GetObjects().end() || !objectIt->second->isUnit()) {
+                continue;
+              }
+              ClientUnit* unit = AsUnit(objectIt->second);
               // TODO: check if the targetObject allows this unit #stats
-              suitableUnits.push_back(selection[i]);
+              if (unit->GetType() != UnitType::Scout) {
+                suitableUnits.push_back(selection[i]);
+              }
             }
             
             if (!suitableUnits.empty()) {

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3141,7 +3141,7 @@ void RenderWindow::PressCommandButton(CommandButton* button, bool shift) {
         }
         break;
       case CommandButton::ActionType::UngarrisonAll:
-        // TODO (maanoo): extract to function
+        // TODO: extract to function
         for (u32 id : selection) {
           auto it = map->GetObjects().find(id);
           if (it == map->GetObjects().end()) {

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3151,7 +3151,7 @@ void RenderWindow::PressCommandButton(CommandButton* button, bool shift) {
   
   // Handle building construction.
   if (button->GetType() == CommandButton::Type::ConstructBuilding) {
-    if (SetActiveCommandButton(button, true)) {
+    if (SetActiveCommandButton(button, /*allowToggle*/ true)) {
       constructBuildingType = button->GetBuildingConstructionType(); // TODO (maanoo): move
     }
   }
@@ -3161,10 +3161,13 @@ void RenderWindow::PressCommandButton(CommandButton* button, bool shift) {
 
     switch (button->GetActionType()) {
     case CommandButton::ActionType::Garrison:
-      SetActiveCommandButton(button, true);
+      SetActiveCommandButton(button, /*allowToggle*/ true);
       break;
     default:
-      UnsetActiveCommandButton(); // TODO (maanoo): doc
+      // Up to this point all the toggle-able buttons should have been handled
+      // because now we clear the active command button (and information about 
+      // toggling will be lost).
+      UnsetActiveCommandButton();
 
       switch (button->GetActionType()) {
       case CommandButton::ActionType::BuildEconomyBuilding:
@@ -3181,7 +3184,17 @@ void RenderWindow::PressCommandButton(CommandButton* button, bool shift) {
         }
         break;
       case CommandButton::ActionType::UngarrisonAll:
-      // TODO (maanoo): impl
+        // TODO (maanoo): extract to function
+        for (u32 id : selection) {
+        auto it = map->GetObjects().find(id);
+          if (it == map->GetObjects().end()) {
+            continue;
+          }
+          ClientObject* object = it->second;
+          if (object->GetGarrisonedUnitsCount() > 0) {
+            connection->Write(CreateSetTargetWithInteractionMessage(object->GetGarrisonedUnits(), id, InteractionType::Ungarrison));
+          }
+        }
         break;
       case CommandButton::ActionType::Quit:
         ShowDefaultCommandButtonsForSelection();

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3199,9 +3199,9 @@ void RenderWindow::PressCommandButton(CommandButton* button, bool shift) {
           if (object->GetGarrisonedUnitsCount() > 0) {
             // NOTE: Could be simplified if Objects stored there ID. #ids
             std::vector<u32> unitIds;
-            for (const auto& i : map->GetObjects()) {
-              if (i.second->isUnit() && AsUnit(i.second)->GetGarrisonedInsideObject() == object) {
-                unitIds.push_back(i.first);
+            for (const auto& item : map->GetObjects()) {
+              if (item.second->isUnit() && AsUnit(item.second)->GetGarrisonedInsideObject() == object) {
+                unitIds.push_back(item.first);
               }
             }
             connection->Write(CreateSetTargetWithInteractionMessage(unitIds, id, InteractionType::Ungarrison));
@@ -3421,10 +3421,10 @@ void RenderWindow::UngarrisonUnit(int garrisonedUnitIndex) {
   }
   ClientUnit* garrisonedUnit = objectIt->second->GetGarrisonedUnits().at(garrisonedUnitIndex);
   // NOTE: Could be simplified if Objects stored there ID. #ids
-  for (const auto& i : map->GetObjects()) {
-    if (i.second == garrisonedUnit) {
+  for (const auto& item: map->GetObjects()) {
+    if (item.second == garrisonedUnit) {
       std::vector<u32> unitIds;
-      unitIds.push_back(i.first);
+      unitIds.push_back(item.first);
       connection->Write(CreateSetTargetWithInteractionMessage(unitIds, objectId, InteractionType::Ungarrison));
       return;
     }

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -4040,7 +4040,9 @@ void RenderWindow::mousePressEvent(QMouseEvent* event) {
           // int capacity = stats->garrisonCapacity #stats
           bool isTownCenter = targetObject->GetObjectType() == ObjectType::Building && AsBuilding(targetObject)->GetType() == BuildingType::TownCenter;
           int capacity = isTownCenter ? 15 : 0;
-          if (targetObject->GetGarrisonedUnitsCount() < capacity) {
+          if (capacity) {
+            // Do not check the targetObject->GetGarrisonedUnitsCount() now, by the time the unit 
+            // will reach the bulding the capacity may have changed.
 
             std::vector<u32> suitableUnits;
             suitableUnits.reserve(selection.size());
@@ -4050,7 +4052,7 @@ void RenderWindow::mousePressEvent(QMouseEvent* event) {
             }
             
             if (!suitableUnits.empty()) {
-              // TODO (maanoo): create message
+              connection->Write(CreateSetTargetWithInteractionMessage(suitableUnits, targetObjectId, InteractionType::Garrison));
               
               LetObjectFlash(targetObjectId);
             }
@@ -4298,7 +4300,7 @@ void RenderWindow::UpdateCursor() {
           case InteractionType::CollectGold: cursor = &mineGoldCursor; break;
           case InteractionType::CollectStone: cursor = &mineStoneCursor; break;
           case InteractionType::Garrison: cursor = &garrisonCursor; break;
-          case InteractionType::Invalid: continue;
+          default: continue;
           }
           break;
         }

--- a/src/FreeAge/client/render_window.cpp
+++ b/src/FreeAge/client/render_window.cpp
@@ -3204,7 +3204,7 @@ void RenderWindow::PressCommandButton(CommandButton* button, bool shift) {
                 unitIds.push_back(item.first);
               }
             }
-            connection->Write(CreateSetTargetWithInteractionMessage(unitIds, id, InteractionType::Ungarrison));
+            connection->Write(CreateUngarrisonUnitsMessage(unitIds));
           }
         }
         break;
@@ -3425,7 +3425,7 @@ void RenderWindow::UngarrisonUnit(int garrisonedUnitIndex) {
     if (item.second == garrisonedUnit) {
       std::vector<u32> unitIds;
       unitIds.push_back(item.first);
-      connection->Write(CreateSetTargetWithInteractionMessage(unitIds, objectId, InteractionType::Ungarrison));
+      connection->Write(CreateUngarrisonUnitsMessage(unitIds));
       return;
     }
   }

--- a/src/FreeAge/client/render_window.hpp
+++ b/src/FreeAge/client/render_window.hpp
@@ -66,7 +66,7 @@ class RenderWindow : public QOpenGLWindow {
   inline void SetGameController(const std::shared_ptr<GameController>& gameController) { this->gameController = gameController; }
   
   inline void EnableBorderScrolling(bool enable) { borderScrollingEnabled = enable; }
-  
+
   void AddDecal(Decal* decal);
 
   void GrabMouse();
@@ -198,6 +198,12 @@ class RenderWindow : public QOpenGLWindow {
   void DefineControlGroup(int controlGroupIndex);
   void SelectControlGroup(int controlGroupIndex);
   
+  // TODO (maanoo): do not allow to rectangle select when on has activecommandbutton
+  /// TODO (maanoo): doc
+  CommandButton::State GetCommandButtonState(CommandButton* commandButton);
+  bool SetActiveCommandButton(CommandButton* commandButton, bool allowToggle);
+  bool UnsetActiveCommandButton();
+
   virtual void initializeGL() override;
   virtual void paintGL() override;
   virtual void resizeGL(int width, int height) override;
@@ -234,6 +240,7 @@ class RenderWindow : public QOpenGLWindow {
   QCursor gatherCursor;
   QCursor mineGoldCursor;
   QCursor mineStoneCursor;
+  QCursor garrisonCursor;
   
   /// Current map scroll position in map coordinates.
   /// The "scroll" map coordinate is visible at the center of the screen.
@@ -397,6 +404,8 @@ class RenderWindow : public QOpenGLWindow {
   TextureAndPointBuffer buildEconomyBuildings;
   TextureAndPointBuffer buildMilitaryBuildings;
   TextureAndPointBuffer toggleBuildingsCategory;
+  TextureAndPointBuffer garrison;
+  TextureAndPointBuffer ungarrisonAll;
   TextureAndPointBuffer quit;
   
   TextureAndPointBuffer minimapPanel;
@@ -444,6 +453,7 @@ class RenderWindow : public QOpenGLWindow {
   BuildingType constructBuildingType = BuildingType::NumBuildings;
   
   /// The command button which action is under way. Currently only of Type::ConstructBuilding.
+  /// TODO (maanoo): doc
   CommandButton* activeCommandButton = nullptr;
 
   // Control groups.

--- a/src/FreeAge/client/render_window.hpp
+++ b/src/FreeAge/client/render_window.hpp
@@ -187,6 +187,7 @@ class RenderWindow : public QOpenGLWindow {
   void ShowMilitaryBuildingCommandButtons();
   
   void DequeueProductionQueueItem(int queueIndex);
+  void UngarrisonUnit(int garrisonedUnitIndex);
   
   void JumpToNextTownCenter();
   /// Selects the object and centers the view on it.
@@ -427,6 +428,11 @@ class RenderWindow : public QOpenGLWindow {
   QPointF productionQueueIconsTopLeft[kMaxProductionQueueSize];
   float productionQueueIconsSize[kMaxProductionQueueSize];
   int pressedProductionQueueItem = -1;
+  PointBuffer garrisonUnitsPointBuffers[kMaxGarrisonCapacity];
+  PointBuffer garrisonUnitsOverlayPointBuffers[kMaxGarrisonCapacity];
+  QPointF garrisonUnitsIconsTopLeft[kMaxGarrisonCapacity];
+  float garrisonUnitsIconsSize[kMaxGarrisonCapacity];
+  int pressedGarrisonUnitsItem = -1;
   
   std::shared_ptr<Texture> iconOverlayNormalTexture;
   std::shared_ptr<Texture> iconOverlayNormalExpensiveTexture;

--- a/src/FreeAge/client/render_window.hpp
+++ b/src/FreeAge/client/render_window.hpp
@@ -198,8 +198,6 @@ class RenderWindow : public QOpenGLWindow {
   void DefineControlGroup(int controlGroupIndex);
   void SelectControlGroup(int controlGroupIndex);
   
-  // TODO (maanoo): do not allow to rectangle select when activecommandbutton != nullptr
-
   bool SetActiveCommandButton(CommandButton* commandButton, bool allowToggle);
   bool UnsetActiveCommandButton();
   
@@ -217,7 +215,6 @@ class RenderWindow : public QOpenGLWindow {
   virtual void focusInEvent(QFocusEvent* event) override;
   virtual void focusOutEvent(QFocusEvent* event) override;
   virtual void resizeEvent(QResizeEvent* event) override;
-  
   
   /// Cursor handling.
   bool grabMouse;

--- a/src/FreeAge/client/render_window.hpp
+++ b/src/FreeAge/client/render_window.hpp
@@ -198,11 +198,12 @@ class RenderWindow : public QOpenGLWindow {
   void DefineControlGroup(int controlGroupIndex);
   void SelectControlGroup(int controlGroupIndex);
   
-  // TODO (maanoo): do not allow to rectangle select when on has activecommandbutton
-  /// TODO (maanoo): doc
-  CommandButton::State GetCommandButtonState(CommandButton* commandButton);
+  // TODO (maanoo): do not allow to rectangle select when activecommandbutton != nullptr
+
   bool SetActiveCommandButton(CommandButton* commandButton, bool allowToggle);
   bool UnsetActiveCommandButton();
+  
+  CommandButton::State GetCommandButtonState(CommandButton* commandButton);
 
   virtual void initializeGL() override;
   virtual void paintGL() override;
@@ -443,17 +444,12 @@ class RenderWindow : public QOpenGLWindow {
   
   bool showingEconomyBuildingCommandButtons = false;
 
-  // TODO: Somehow group constructBuildingType and activeCommandButton to avoid
-  // setting the one and not the other. Could also be generalized for other types of commands
-  // that need more input than a press of the button (eg. attack move, set gather point,
-  // garrison)
-
   /// The type of building that the user is about to place a foundation for.
   /// If not constructing a building, this is set to BuildingType::NumBuildings.
+  /// TODO: Remove and use the activeCommandButton->GetUnitProductionType() to unify all command buttons.
   BuildingType constructBuildingType = BuildingType::NumBuildings;
   
   /// The command button which action is under way. Currently only of Type::ConstructBuilding.
-  /// TODO (maanoo): doc
   CommandButton* activeCommandButton = nullptr;
 
   // Control groups.

--- a/src/FreeAge/client/unit.cpp
+++ b/src/FreeAge/client/unit.cpp
@@ -430,7 +430,7 @@ void ClientUnit::UpdateMapCoord(double serverTime, Map* map, Match* match) {
   
   if (match->GetPlayerIndex() == playerIndex &&
       (oldTileX != newTileX ||
-       oldTileY != newTileY)) {
+       oldTileY != newTileY) && !IsGarrisoned()) {
     // TODO: This could be sped up by pre-computing only the *difference* that needs to be applied
     //       for a unit's line-of-sight when moving from one tile to an adjacent tile.
     //       Even without this pre-computation, iterating over the viewCount values only once

--- a/src/FreeAge/client/unit.cpp
+++ b/src/FreeAge/client/unit.cpp
@@ -373,7 +373,7 @@ void ClientUnit::SetMovementSegment(double serverTime, const QPointF& startPoint
 }
 
 void ClientUnit::UpdateGameState(double serverTime, Map* map, Match* match) {
-  // Update the unit's movment according to the movement segment.
+  // Update the unit's movement according to the movement segment.
   UpdateMapCoord(serverTime, map, match);
   
   // Update facing direction.

--- a/src/FreeAge/client/unit.hpp
+++ b/src/FreeAge/client/unit.hpp
@@ -116,7 +116,10 @@ class ClientUnit : public ClientObject {
   
   Texture& GetTexture(bool shadow);
   
-  inline const QPointF& GetMapCoord() const { return mapCoord; }
+  inline const QPointF& GetMapCoord() const { 
+    CHECK_EQ(IsGarrisoned(), false);
+    return mapCoord;
+  }
   inline int GetDirection() const { return direction; }
   
   void SetMovementSegment(double serverTime, const QPointF& startPoint, const QPointF& speed, UnitAction action, Map* map, Match* match);

--- a/src/FreeAge/client/unit.hpp
+++ b/src/FreeAge/client/unit.hpp
@@ -116,8 +116,10 @@ class ClientUnit : public ClientObject {
   
   Texture& GetTexture(bool shadow);
   
-  inline const QPointF& GetMapCoord() const { 
-    CHECK_EQ(IsGarrisoned(), false);
+  inline const QPointF& GetMapCoord() const {
+    if (IsGarrisoned()) {
+      LOG(ERROR) << "GetMapCoord() must not be called on garrisoned units.";
+    }
     return mapCoord;
   }
   inline int GetDirection() const { return direction; }

--- a/src/FreeAge/client/unit.hpp
+++ b/src/FreeAge/client/unit.hpp
@@ -124,6 +124,9 @@ class ClientUnit : public ClientObject {
   
   void SetMovementSegment(double serverTime, const QPointF& startPoint, const QPointF& speed, UnitAction action, Map* map, Match* match);
   
+  // Must be called after teleport like position changes.
+  inline void ClearOverrideDirection() { overrideDirectionExpireTime = -1; }
+
   inline bool IsGarrisoned() const { return garrisonedObjectId != kInvalidObjectId; }
 
   inline void SetCarriedResources(ResourceType type, u8 amount) {

--- a/src/FreeAge/client/unit.hpp
+++ b/src/FreeAge/client/unit.hpp
@@ -121,12 +121,16 @@ class ClientUnit : public ClientObject {
   
   void SetMovementSegment(double serverTime, const QPointF& startPoint, const QPointF& speed, UnitAction action, Map* map, Match* match);
   
+  inline bool IsGarrisoned() const { return garrisonedObjectId != kInvalidObjectId; }
+
   inline void SetCarriedResources(ResourceType type, u8 amount) {
     carriedResourceType = type;
     carriedResourceAmount = amount;
   }
   inline ResourceType GetCarriedResourceType() const { return carriedResourceType; }
   inline int GetCarriedResourceAmount() const { return carriedResourceAmount; }
+
+  inline void SetGarrisonedInsideObject(u32 objectId) { garrisonedObjectId = objectId; }
   
   /// Updates the unit's state to the given server time.
   void UpdateGameState(double serverTime, Map* map, Match* match);
@@ -151,6 +155,9 @@ class ClientUnit : public ClientObject {
   
   /// If this is in the past, then overrideDirection must be ignored.
   double overrideDirectionExpireTime = -1;
+  
+  /// The object in which the unit is garrisoned
+  u32 garrisonedObjectId = kInvalidObjectId;
   
   UnitAnimation currentAnimation;
   int currentAnimationVariant;

--- a/src/FreeAge/client/unit.hpp
+++ b/src/FreeAge/client/unit.hpp
@@ -127,7 +127,7 @@ class ClientUnit : public ClientObject {
   // Must be called after teleport like position changes.
   inline void ClearOverrideDirection() { overrideDirectionExpireTime = -1; }
 
-  inline bool IsGarrisoned() const { return garrisonedObjectId != kInvalidObjectId; }
+  inline bool IsGarrisoned() const { return garrisonedObject != nullptr; }
 
   inline void SetCarriedResources(ResourceType type, u8 amount) {
     carriedResourceType = type;
@@ -136,7 +136,8 @@ class ClientUnit : public ClientObject {
   inline ResourceType GetCarriedResourceType() const { return carriedResourceType; }
   inline int GetCarriedResourceAmount() const { return carriedResourceAmount; }
 
-  inline void SetGarrisonedInsideObject(u32 objectId) { garrisonedObjectId = objectId; }
+  inline void SetGarrisonedInsideObject(ClientObject* object) { garrisonedObject = object; }
+  inline ClientObject* GetGarrisonedInsideObject() const { return garrisonedObject; }
   
   /// Updates the unit's state to the given server time.
   void UpdateGameState(double serverTime, Map* map, Match* match);
@@ -162,8 +163,8 @@ class ClientUnit : public ClientObject {
   /// If this is in the past, then overrideDirection must be ignored.
   double overrideDirectionExpireTime = -1;
   
-  /// The object in which the unit is garrisoned
-  u32 garrisonedObjectId = kInvalidObjectId;
+  /// The object in which the unit is garrisoned, or nullptr if not garrisoned.
+  ClientObject* garrisonedObject = nullptr;
   
   UnitAnimation currentAnimation;
   int currentAnimationVariant;

--- a/src/FreeAge/common/free_age.hpp
+++ b/src/FreeAge/common/free_age.hpp
@@ -46,6 +46,9 @@ static constexpr int kGaiaPlayerIndex = 255;
 /// The maximum capacity of production queues in buildings.
 static constexpr int kMaxProductionQueueSize = 11;
 
+/// The maximum capacity of garrison units.
+static constexpr int kMaxGarrisonCapacity = 30;
+
 // The M_PI definition might be missing sometimes, so ensure that it is present.
 #ifndef M_PI
     #define M_PI 3.14159265358979323846

--- a/src/FreeAge/common/messages.cpp
+++ b/src/FreeAge/common/messages.cpp
@@ -183,6 +183,26 @@ QByteArray CreateSetTargetWithInteractionMessage(const std::vector<u32>& unitIds
   return msg;
 }
 
+QByteArray CreateUngarrisonUnitsMessage(const std::vector<u32>& unitIds) {
+  if (unitIds.empty()) {
+    return QByteArray();
+  }
+
+  // Create buffer
+  QByteArray msg = CreateClientToServerMessageHeader(2 + 4 * unitIds.size(), ClientToServerMessage::UngarrisonUnits);
+  char* data = msg.data();
+  
+  // Fill buffer
+  mango::ustore16(data + 3, unitIds.size());  // TODO: This could also be derived from the message length
+  int offset = 5;
+  for (u32 unitId : unitIds) {
+    mango::ustore32(data + offset, unitId);
+    offset += 4;
+  }
+
+  return msg;
+}
+
 QByteArray CreateProduceUnitMessage(u32 buildingId, u16 unitType) {
   QByteArray msg = CreateClientToServerMessageHeader(6, ClientToServerMessage::ProduceUnit);
   char* data = msg.data();

--- a/src/FreeAge/common/messages.cpp
+++ b/src/FreeAge/common/messages.cpp
@@ -163,7 +163,7 @@ QByteArray CreateSetTargetWithInteractionMessage(const std::vector<u32>& unitIds
   if (unitIds.empty()) {
     return QByteArray();
   }
-  
+
   // Create buffer
   QByteArray msg = CreateClientToServerMessageHeader(10 + 4 * unitIds.size(), ClientToServerMessage::SetTargetWithInteraction);
   char* data = msg.data();

--- a/src/FreeAge/common/messages.cpp
+++ b/src/FreeAge/common/messages.cpp
@@ -159,6 +159,30 @@ QByteArray CreateSetTargetMessage(const std::vector<u32>& unitIds, u32 targetObj
   return msg;
 }
 
+QByteArray CreateSetTargetWithInteractionMessage(const std::vector<u32>& unitIds, u32 targetObjectId, InteractionType interaction) {
+  if (unitIds.empty()) {
+    return QByteArray();
+  }
+  
+  // Create buffer
+  QByteArray msg = CreateClientToServerMessageHeader(10 + 4 * unitIds.size(), ClientToServerMessage::SetTargetWithInteraction);
+  char* data = msg.data();
+  
+  // Fill buffer
+  mango::ustore32(data + 3, targetObjectId);
+
+  mango::ustore16(data + 7, unitIds.size());  // TODO: This could also be derived from the message length
+  int offset = 9;
+  for (u32 unitId : unitIds) {
+    mango::ustore32(data + offset, unitId);
+    offset += 4;
+  }
+
+  mango::ustore32(data + offset, static_cast<u32>(interaction)); // TODO: reduce size ?
+  
+  return msg;
+}
+
 QByteArray CreateProduceUnitMessage(u32 buildingId, u16 unitType) {
   QByteArray msg = CreateClientToServerMessageHeader(6, ClientToServerMessage::ProduceUnit);
   char* data = msg.data();
@@ -303,6 +327,14 @@ QByteArray CreateUnitMovementMessage(u32 unitId, const QPointF& startPoint, cons
   *reinterpret_cast<float*>(data + 15) = speed.x();
   *reinterpret_cast<float*>(data + 19) = speed.y();
   data[23] = static_cast<u8>(action);
+  return msg;
+}
+
+QByteArray CreateUnitGarrisonMessage(u32 unitId, u32 targetObjectId) {
+  QByteArray msg = CreateServerToClientMessageHeader(8, ServerToClientMessage::UnitGarrison);
+  char* data = msg.data();
+  mango::ustore32(data + 3, unitId);
+  mango::ustore32(data + 7, targetObjectId);
   return msg;
 }
 

--- a/src/FreeAge/common/messages.hpp
+++ b/src/FreeAge/common/messages.hpp
@@ -82,7 +82,6 @@ enum class ClientToServerMessage {
   SetTarget,
 
   /// Same as SetTarget but with the interaction specified.
-  /// TODO: extend doc and rename ?
   SetTargetWithInteraction,
   
   /// Sent upon pressing the button / hotkey to produce a unit.

--- a/src/FreeAge/common/messages.hpp
+++ b/src/FreeAge/common/messages.hpp
@@ -206,8 +206,7 @@ enum class ServerToClientMessage {
   /// The speed may be zero, which indicates that the unit has stopped moving.
   UnitMovement,
   
-  /// TODO (maanoo): doc, 
-  // For now, the same message for garrison and ungarrison.
+  /// Tells the client that a unit is garrisoned or ungarrisoned from an object (building or unit).
   UnitGarrison,
 
   /// Tells the client about updates to its game resource amounts (wood, food, etc.)

--- a/src/FreeAge/common/messages.hpp
+++ b/src/FreeAge/common/messages.hpp
@@ -11,6 +11,7 @@
 
 #include "FreeAge/common/building_types.hpp"
 #include "FreeAge/common/free_age.hpp"
+#include "FreeAge/common/object_types.hpp"
 #include "FreeAge/common/unit_types.hpp"
 
 
@@ -79,6 +80,10 @@ enum class ClientToServerMessage {
   /// * Moving a monk with a relic to a monastery drops off the relic in the monastery.
   /// * Moving a trade cart / cog to an allied market / dock starts trading with it.
   SetTarget,
+
+  /// Same as SetTarget but with the interaction specified.
+  /// TODO: extend doc and rename ?
+  SetTargetWithInteraction,
   
   /// Sent upon pressing the button / hotkey to produce a unit.
   ProduceUnit,
@@ -126,6 +131,11 @@ QByteArray CreateMoveToMapCoordMessage(
 QByteArray CreateSetTargetMessage(
     const std::vector<u32>& unitIds,
     u32 targetObjectId);
+
+QByteArray CreateSetTargetWithInteractionMessage(
+    const std::vector<u32>& unitIds,
+    u32 targetObjectId,
+    InteractionType interaction);
 
 QByteArray CreateProduceUnitMessage(
     u32 buildingId,
@@ -196,6 +206,10 @@ enum class ServerToClientMessage {
   /// The speed may be zero, which indicates that the unit has stopped moving.
   UnitMovement,
   
+  /// TODO (maanoo): doc, 
+  // For now, the same message for garrison and ungarrison.
+  UnitGarrison,
+
   /// Tells the client about updates to its game resource amounts (wood, food, etc.)
   ResourcesUpdate,
   
@@ -270,6 +284,8 @@ QByteArray CreateUnitMovementMessage(
     const QPointF& startPoint,
     const QPointF& speed,
     UnitAction action);
+
+QByteArray CreateUnitGarrisonMessage(u32 unitId, u32 targetObjectId);
 
 QByteArray CreateResourcesUpdateMessage(const ResourceAmount& amount);
 

--- a/src/FreeAge/common/messages.hpp
+++ b/src/FreeAge/common/messages.hpp
@@ -83,6 +83,9 @@ enum class ClientToServerMessage {
 
   /// Same as SetTarget but with the interaction specified.
   SetTargetWithInteraction,
+
+  /// An ungarrison command to selection of units.
+  UngarrisonUnits,
   
   /// Sent upon pressing the button / hotkey to produce a unit.
   ProduceUnit,
@@ -135,6 +138,9 @@ QByteArray CreateSetTargetWithInteractionMessage(
     const std::vector<u32>& unitIds,
     u32 targetObjectId,
     InteractionType interaction);
+
+QByteArray CreateUngarrisonUnitsMessage(
+    const std::vector<u32>& unitIds);
 
 QByteArray CreateProduceUnitMessage(
     u32 buildingId,

--- a/src/FreeAge/common/object_types.hpp
+++ b/src/FreeAge/common/object_types.hpp
@@ -18,7 +18,7 @@ constexpr u32 kInvalidObjectId = std::numeric_limits<u32>::max();
 enum class InteractionType {
   // A pseudo intercation type that describes that intercation is not specified and 
   // must be determined by a call to GetInteractionType. To not be confused with ::Invalid.
-  Unknown = 0,
+  Default = 0,
 
   // A villager constructs a building.
   Construct,

--- a/src/FreeAge/common/object_types.hpp
+++ b/src/FreeAge/common/object_types.hpp
@@ -36,6 +36,7 @@ enum class InteractionType {
 
   // A unit garrison in a other unit or building.
   Garrison,
+  Ungarrison,
   
   // No valid interaction.
   Invalid

--- a/src/FreeAge/common/object_types.hpp
+++ b/src/FreeAge/common/object_types.hpp
@@ -30,6 +30,9 @@ enum class InteractionType {
   
   // A unit attacks an enemy unit or building
   Attack,
+
+  // TODO (maanoo): ??, implement in some cases in GetInteractionType
+  Garrison,
   
   // No valid interaction.
   Invalid

--- a/src/FreeAge/common/object_types.hpp
+++ b/src/FreeAge/common/object_types.hpp
@@ -16,8 +16,11 @@ enum class ObjectType {
 constexpr u32 kInvalidObjectId = std::numeric_limits<u32>::max();
 
 enum class InteractionType {
+  // TODO (maanoo): doc
+  Unknown = 0,
+
   // A villager constructs a building.
-  Construct = 0,
+  Construct,
   
   // A villager collects a resource.
   CollectBerries,
@@ -31,7 +34,7 @@ enum class InteractionType {
   // A unit attacks an enemy unit or building
   Attack,
 
-  // TODO (maanoo): ??, implement in some cases in GetInteractionType
+  // A unit garrison in a other unit or building.
   Garrison,
   
   // No valid interaction.

--- a/src/FreeAge/common/object_types.hpp
+++ b/src/FreeAge/common/object_types.hpp
@@ -16,7 +16,8 @@ enum class ObjectType {
 constexpr u32 kInvalidObjectId = std::numeric_limits<u32>::max();
 
 enum class InteractionType {
-  // TODO (maanoo): doc
+  // A pseudo intercation type that describes that intercation is not specified and 
+  // must be determined by a call to GetInteractionType. To not be confused with ::Invalid.
   Unknown = 0,
 
   // A villager constructs a building.

--- a/src/FreeAge/common/object_types.hpp
+++ b/src/FreeAge/common/object_types.hpp
@@ -37,7 +37,6 @@ enum class InteractionType {
 
   // A unit garrison in a other unit or building.
   Garrison,
-  Ungarrison,
   
   // No valid interaction.
   Invalid

--- a/src/FreeAge/server/game.cpp
+++ b/src/FreeAge/server/game.cpp
@@ -964,7 +964,7 @@ void Game::SimulateGameStepForUnit(u32 unitId, ServerUnit* unit, double gameStep
       } else {
         ServerObject* targetObject = targetIt->second;
         InteractionType interaction = unit->GetTargetObjectInteraction();
-        if (interaction == InteractionType::Unknown) { // TODO (maanoo): move this check inside the GetTargetObjectInteraction
+        if (interaction == InteractionType::Unknown) {
           interaction = GetInteractionType(unit, targetObject);
         }
         if (targetObject->isBuilding()) {
@@ -986,11 +986,11 @@ void Game::SimulateGameStepForUnit(u32 unitId, ServerUnit* unit, double gameStep
               // TODO (maanoo): extract to function
               targetBuilding->GarrisonUnit(unitId);
               unit->SetGarrisonedInsideObject(targetObjectId);
-              unit->SetMapCoord(targetBuilding->GetBaseTile()); // TODO (maanoo): take the center of the building
+              unit->SetMapCoord(targetBuilding->GetBaseTile()); // TODO (maanoo): take the center of the building ?
               unit->SetMovementDirection(QPointF(0, 0));
               unit->StopMovement();
               unit->RemoveTarget();
-              // TODO (maanoo): what else ?
+
               accumulatedMessages[unit->GetPlayerIndex()] += CreateUnitGarrisonMessage(unitId, targetObjectId);
               accumulatedMessages[unit->GetPlayerIndex()] +=
                   CreateUnitMovementMessage(
@@ -1006,7 +1006,7 @@ void Game::SimulateGameStepForUnit(u32 unitId, ServerUnit* unit, double gameStep
                 unit->SetMapCoord(freeSpace);
                 unit->StopMovement();
                 unit->RemoveTarget();
-                // TODO (maanoo): what else ?
+
                 accumulatedMessages[unit->GetPlayerIndex()] += CreateUnitGarrisonMessage(unitId, targetObjectId);
                 // TODO: move to the gather point #gather-point
                 accumulatedMessages[unit->GetPlayerIndex()] +=

--- a/src/FreeAge/server/game.cpp
+++ b/src/FreeAge/server/game.cpp
@@ -1419,10 +1419,10 @@ void Game::ProduceUnit(ServerBuilding* building, UnitType unitInProduction) {
 }
 
 void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter) {
-  // TODO: implement a way to get ID from ClientObject, then remove the ids for the arguments
+  // NOTE: If ServerObject stores its ID, the IDs could be removed from the arguments. #ids
   if (enter) {
-    targetObject->GarrisonUnit(unitId);
-    unit->SetGarrisonedInsideObject(targetObjectId);
+    targetObject->GarrisonUnit(unit);
+    unit->SetGarrisonedInsideObject(targetObject);
     unit->StopMovement();
     unit->RemoveTarget();
 
@@ -1438,8 +1438,8 @@ void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, Server
     }
     ServerBuilding* targetBuilding = AsBuilding(targetObject);
     if (QPointF freeSpace; FindFreeSpaceAroundBuilding(targetBuilding, unit, freeSpace)) {
-      targetBuilding->UngarrisonUnit(unitId);
-      unit->SetGarrisonedInsideObject(kInvalidObjectId);
+      targetBuilding->UngarrisonUnit(unit);
+      unit->SetGarrisonedInsideObject(nullptr);
       unit->SetMapCoord(freeSpace);
       unit->StopMovement();
       unit->RemoveTarget();

--- a/src/FreeAge/server/game.cpp
+++ b/src/FreeAge/server/game.cpp
@@ -1427,7 +1427,12 @@ void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, Server
     unit->RemoveTarget();
 
     QByteArray unitGarrisonMessage = CreateUnitGarrisonMessage(unitId, targetObjectId);
+    QByteArray unitMoveMessage = CreateUnitMovementMessage(unitId,
+        unit->GetMapCoord(),
+        unit->GetMoveSpeed() * unit->GetMovementDirection(),
+        unit->GetCurrentAction());
     for (auto& player : *playersInGame) {
+      accumulatedMessages[player->index] += unitMoveMessage;
       accumulatedMessages[player->index] += unitGarrisonMessage;
     }
   } else {

--- a/src/FreeAge/server/game.cpp
+++ b/src/FreeAge/server/game.cpp
@@ -984,8 +984,10 @@ void Game::SimulateGameStepForUnit(u32 unitId, ServerUnit* unit, double gameStep
               SimulateMeleeAttack(unitId, unit, targetIt->first, targetBuilding, gameStepServerTime, stepLengthInSeconds, &unitMovementChanged, &stayInPlace);
             } else if (interaction == InteractionType::Garrison) {
               GarrisonUnit(unitId, unit, targetObjectId, targetObject, true);
+              unitMovementChanged = false;
             } else if (interaction == InteractionType::Ungarrison) {
               GarrisonUnit(unitId, unit, targetObjectId, targetObject, false);
+              unitMovementChanged = false;
             }
           }
         } else if (targetObject->isUnit()) {
@@ -1425,13 +1427,8 @@ void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, Server
     unit->RemoveTarget();
 
     QByteArray unitGarrisonMessage = CreateUnitGarrisonMessage(unitId, targetObjectId);
-    QByteArray unitMoveMessage = CreateUnitMovementMessage(unitId,
-      unit->GetMapCoord(),
-      unit->GetMoveSpeed() * unit->GetMovementDirection(),
-      unit->GetCurrentAction());
     for (auto& player : *playersInGame) {
       accumulatedMessages[player->index] += unitGarrisonMessage;
-      accumulatedMessages[player->index] += unitMoveMessage;
     }
   } else {
     if (!targetObject->isBuilding()) {
@@ -1454,8 +1451,8 @@ void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, Server
         unit->GetMoveSpeed() * unit->GetMovementDirection(),
         unit->GetCurrentAction());
       for (auto& player : *playersInGame) {
-        accumulatedMessages[player->index] += unitGarrisonMessage;
         accumulatedMessages[player->index] += unitMoveMessage;
+        accumulatedMessages[player->index] += unitGarrisonMessage;
       }
     } else {
       LOG(WARNING) << "No free space for unit " << unitId << " to ungarrison object " << targetObjectId;

--- a/src/FreeAge/server/game.cpp
+++ b/src/FreeAge/server/game.cpp
@@ -995,9 +995,9 @@ void Game::SimulateGameStepForUnit(u32 unitId, ServerUnit* unit, double gameStep
             if (interaction == InteractionType::Attack) {
               SimulateMeleeAttack(unitId, unit, targetIt->first, targetUnit, gameStepServerTime, stepLengthInSeconds, &unitMovementChanged, &stayInPlace);
             } else if (interaction == InteractionType::Garrison) {
-              // TODO: implement
+              GarrisonUnit(unitId, unit, targetObjectId, targetObject, true, &unitMovementChanged);
             } else if (interaction == InteractionType::Ungarrison) {
-              // TODO: implement
+              GarrisonUnit(unitId, unit, targetObjectId, targetObject, false, &unitMovementChanged);
             }
           }
         }
@@ -1438,8 +1438,9 @@ void Game::ProduceUnit(u32 buildingId, ServerBuilding* building, UnitType unitIn
 
 void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter, bool* unitMovementChanged) {
   // NOTE: Could be simplified if Objects stored there ID. #ids
-  *unitMovementChanged = false; // movement will handled here
+  *unitMovementChanged = false;
   if (enter) {
+    // TODO: test with target object being a unit
 
     unit->StopMovement();
     unit->RemoveTarget();
@@ -1475,8 +1476,8 @@ void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, Server
     }
   } else {
     if (!targetObject->isBuilding()) {
-      // TODO: implement ungarrison from unit
-      LOG(WARNING) << "Ungarrison from unit not implemented yet";
+      // TODO: find an empty spot around the target unit and ungarrison their
+      LOG(ERROR) << "Ungarrison from unit not implemented yet";
       return;
     }
     ServerBuilding* targetBuilding = AsBuilding(targetObject);

--- a/src/FreeAge/server/game.cpp
+++ b/src/FreeAge/server/game.cpp
@@ -1424,8 +1424,8 @@ void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, Server
     unit->StopMovement();
     unit->RemoveTarget();
 
-    auto unitGarrisonMessage = CreateUnitGarrisonMessage(unitId, targetObjectId);
-    auto unitMoveMessage = CreateUnitMovementMessage(unitId,
+    QByteArray unitGarrisonMessage = CreateUnitGarrisonMessage(unitId, targetObjectId);
+    QByteArray unitMoveMessage = CreateUnitMovementMessage(unitId,
       unit->GetMapCoord(),
       unit->GetMoveSpeed() * unit->GetMovementDirection(),
       unit->GetCurrentAction());
@@ -1447,9 +1447,9 @@ void Game::GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, Server
       unit->StopMovement();
       unit->RemoveTarget();
 
-      auto unitGarrisonMessage = CreateUnitGarrisonMessage(unitId, targetObjectId);
+      QByteArray unitGarrisonMessage = CreateUnitGarrisonMessage(unitId, targetObjectId);
       // TODO: move to the gather point #gather-point
-      auto unitMoveMessage = CreateUnitMovementMessage(unitId,
+      QByteArray unitMoveMessage = CreateUnitMovementMessage(unitId,
         unit->GetMapCoord(),
         unit->GetMoveSpeed() * unit->GetMovementDirection(),
         unit->GetCurrentAction());

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -118,6 +118,8 @@ class Game {
   
   void ProduceUnit(ServerBuilding* building, UnitType unitInProduction);
 
+  void GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter);
+
   bool FindFreeSpaceAroundBuilding(ServerBuilding* building, ServerUnit* unit, QPointF& freeSpace);
 
   void SetUnitTargets(const std::vector<u32>& unitIds, int playerIndex, u32 targetId, ServerObject* targetObject, bool isManualTargeting, InteractionType interaction = InteractionType::Unknown);

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -118,7 +118,10 @@ class Game {
   
   void ProduceUnit(u32 buildingId, ServerBuilding* building, UnitType unitInProduction);
 
+  /// Change the garrison state of a unit and the targets object garrisoned units list. 
+  /// The enter parameter is true for garrison and false for ungarrison.
   void GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter, bool* unitMovementChanged);
+  
   void UngarrisonAllUnits(u32 targetObjectId, ServerObject* targetObject);
 
   bool FindFreeSpaceAroundBuilding(ServerBuilding* building, ServerUnit* unit, QPointF& freeSpace);

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -92,6 +92,7 @@ class Game {
   void HandleMoveToMapCoordMessage(const QByteArray& msg, PlayerInGame* player, u32 len);
   void HandleSetTargetMessage(const QByteArray& msg, PlayerInGame* player, u32 len);
   void HandleSetTargetWithInteractionMessage(const QByteArray& msg, PlayerInGame* player, u32 len);
+  void HandleUngarrisonUnitsMessage(const QByteArray& msg, PlayerInGame* player, u32 len);
   void HandleProduceUnitMessage(const QByteArray& msg, PlayerInGame* player);
   void HandlePlaceBuildingFoundationMessage(const QByteArray& msg, PlayerInGame* player);
   void HandleDeleteObjectMessage(const QByteArray& msg, PlayerInGame* player);
@@ -118,15 +119,19 @@ class Game {
   
   void ProduceUnit(u32 buildingId, ServerBuilding* building, UnitType unitInProduction);
 
+  bool GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject);
+  bool UngarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject);
+  void UngarrisonAllUnits(u32 targetObjectId, ServerObject* targetObject);
+  
   /// Change the garrison state of a unit and the targets object garrisoned units list. 
   /// The enter parameter is true for garrison and false for ungarrison.
-  void GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter, bool* unitMovementChanged);
-  
-  void UngarrisonAllUnits(u32 targetObjectId, ServerObject* targetObject);
+  /// Returns true if the unit's garrison status changed.
+  bool ChangeUnitGarrisonStatus(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter);
 
   bool FindFreeSpaceAroundBuilding(ServerBuilding* building, ServerUnit* unit, QPointF& freeSpace);
 
-  void SetUnitTargets(const std::vector<u32>& unitIds, int playerIndex, u32 targetId, ServerObject* targetObject, bool isManualTargeting, InteractionType interaction = InteractionType::Unknown);
+  void SetUnitTargets(const std::vector<u32>& unitIds, int playerIndex, u32 targetId, ServerObject* targetObject, bool isManualTargeting, InteractionType interaction = InteractionType::Default);
+  void UngarrisonUnits(const std::vector<u32>& unitIds, int playerIndex);
   
   void DeleteObject(u32 objectId, bool deletedManually);
   

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -116,7 +116,7 @@ class Game {
   /// Returns true if the attack is still in progress, false if it finished.
   bool SimulateMeleeAttack(u32 unitId, ServerUnit* unit, u32 targetId, ServerObject* target, double gameStepServerTime, float stepLengthInSeconds, bool* unitMovementChanged, bool* stayInPlace);
   
-  void ProduceUnit(ServerBuilding* building, UnitType unitInProduction);
+  void ProduceUnit(u32 buildingId, ServerBuilding* building, UnitType unitInProduction);
 
   void GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter, bool* unitMovementChanged);
   void UngarrisonAllUnits(u32 targetObjectId, ServerObject* targetObject);

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -118,7 +118,7 @@ class Game {
   
   void ProduceUnit(ServerBuilding* building, UnitType unitInProduction);
 
-  void GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter);
+  void GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter, bool* unitMovementChanged);
   void UngarrisonAllUnits(u32 targetObjectId, ServerObject* targetObject);
 
   bool FindFreeSpaceAroundBuilding(ServerBuilding* building, ServerUnit* unit, QPointF& freeSpace);

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -117,7 +117,9 @@ class Game {
   bool SimulateMeleeAttack(u32 unitId, ServerUnit* unit, u32 targetId, ServerObject* target, double gameStepServerTime, float stepLengthInSeconds, bool* unitMovementChanged, bool* stayInPlace);
   
   void ProduceUnit(ServerBuilding* building, UnitType unitInProduction);
-  
+
+  bool FindFreeSpaceAroundBuilding(ServerBuilding* building, ServerUnit* unit, QPointF& freeSpace);
+
   void SetUnitTargets(const std::vector<u32>& unitIds, int playerIndex, u32 targetId, ServerObject* targetObject, bool isManualTargeting, InteractionType interaction = InteractionType::Unknown);
   
   void DeleteObject(u32 objectId, bool deletedManually);

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -119,6 +119,7 @@ class Game {
   void ProduceUnit(ServerBuilding* building, UnitType unitInProduction);
 
   void GarrisonUnit(u32 unitId, ServerUnit* unit, u32 targetObjectId, ServerObject* targetObject, bool enter);
+  void UngarrisonAllUnits(u32 targetObjectId, ServerObject* targetObject);
 
   bool FindFreeSpaceAroundBuilding(ServerBuilding* building, ServerUnit* unit, QPointF& freeSpace);
 

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -91,6 +91,7 @@ class Game {
   void HandlePing(const QByteArray& msg, PlayerInGame* player);
   void HandleMoveToMapCoordMessage(const QByteArray& msg, PlayerInGame* player, u32 len);
   void HandleSetTargetMessage(const QByteArray& msg, PlayerInGame* player, u32 len);
+  void HandleSetTargetWithInteractionMessage(const QByteArray& msg, PlayerInGame* player, u32 len);
   void HandleProduceUnitMessage(const QByteArray& msg, PlayerInGame* player);
   void HandlePlaceBuildingFoundationMessage(const QByteArray& msg, PlayerInGame* player);
   void HandleDeleteObjectMessage(const QByteArray& msg, PlayerInGame* player);
@@ -117,7 +118,7 @@ class Game {
   
   void ProduceUnit(ServerBuilding* building, UnitType unitInProduction);
   
-  void SetUnitTargets(const std::vector<u32>& unitIds, int playerIndex, u32 targetId, ServerObject* targetObject, bool isManualTargeting);
+  void SetUnitTargets(const std::vector<u32>& unitIds, int playerIndex, u32 targetId, ServerObject* targetObject, bool isManualTargeting, InteractionType interaction = InteractionType::Unknown);
   
   void DeleteObject(u32 objectId, bool deletedManually);
   

--- a/src/FreeAge/server/map.cpp
+++ b/src/FreeAge/server/map.cpp
@@ -438,6 +438,9 @@ bool ServerMap::DoesUnitCollide(ServerUnit* unit, const QPointF& mapCoord, Serve
     ServerObject* object = item.second;
     if (object->isUnit() && object != unit) {
       ServerUnit* otherUnit = AsUnit(object);
+      if (otherUnit->IsGarrisoned()) {
+        continue;
+      }
       
       float otherRadius = GetUnitRadius(otherUnit->GetType());
       QPointF offset = otherUnit->GetMapCoord() - mapCoord;

--- a/src/FreeAge/server/object.cpp
+++ b/src/FreeAge/server/object.cpp
@@ -7,12 +7,22 @@
 #include "FreeAge/server/building.hpp"
 #include "FreeAge/server/unit.hpp"
 
-void ServerObject::GarrisonUnit(u32 unitId) { 
-  garrisonedUnits.emplace_back(unitId);
+void ServerObject::GarrisonUnit(ServerUnit* unit) {
+  garrisonedUnits.push_back(unit);
 }
 
-void ServerObject::UngarrisonUnit(u32 unitId) {
-  garrisonedUnits.erase(std::remove(garrisonedUnits.begin(), garrisonedUnits.end(), unitId), garrisonedUnits.end());
+void ServerObject::UngarrisonUnit(ServerUnit* unit) {
+  bool found = false;
+  for (usize i = 0, size = garrisonedUnits.size(); i < size; ++ i) {
+    if (garrisonedUnits[i] == unit) {
+      garrisonedUnits.erase(garrisonedUnits.begin() + i);
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    LOG(ERROR) << "Did not find unit to ungarrison in garrisonedUnits";
+  }
 }
 
 InteractionType GetInteractionType(ServerObject* actor, ServerObject* target) {

--- a/src/FreeAge/server/object.cpp
+++ b/src/FreeAge/server/object.cpp
@@ -47,8 +47,9 @@ InteractionType GetInteractionType(ServerObject* actor, ServerObject* target) {
         target->GetPlayerIndex() != kGaiaPlayerIndex) {
       return InteractionType::Attack;
     }
-    
-    // TODO (maanoo): add Garrison, all cases cannot be handled here, the user has to use the garrison button in some cases
+
+    // TODO: return InteractionType::Garrison only for targets that are mainly used for garrison, like the
+    //       the transport ship and rams.
   }
   
   return InteractionType::Invalid;

--- a/src/FreeAge/server/object.cpp
+++ b/src/FreeAge/server/object.cpp
@@ -7,6 +7,14 @@
 #include "FreeAge/server/building.hpp"
 #include "FreeAge/server/unit.hpp"
 
+void ServerObject::GarrisonUnit(u32 unitId) { 
+  garrisonedUnits.emplace_back(unitId);
+}
+
+void ServerObject::UngarrisonUnit(u32 unitId) {
+  garrisonedUnits.erase(std::remove(garrisonedUnits.begin(), garrisonedUnits.end(), unitId), garrisonedUnits.end());
+}
+
 InteractionType GetInteractionType(ServerObject* actor, ServerObject* target) {
   // TODO: There is a copy of this function in the client code. Can we merge these copies?
   
@@ -39,6 +47,8 @@ InteractionType GetInteractionType(ServerObject* actor, ServerObject* target) {
         target->GetPlayerIndex() != kGaiaPlayerIndex) {
       return InteractionType::Attack;
     }
+    
+    // TODO (maanoo): add Garrison, all cases cannot be handled here, the user has to use the garrison button in some cases
   }
   
   return InteractionType::Invalid;

--- a/src/FreeAge/server/object.hpp
+++ b/src/FreeAge/server/object.hpp
@@ -10,13 +10,15 @@
 #include "FreeAge/common/free_age.hpp"
 #include "FreeAge/common/object_types.hpp"
 
+class ServerUnit;
+
 /// Base class for game objects (buildings and units).
 class ServerObject {
  public:
   inline ServerObject(ObjectType objectType, int playerIndex)
       : playerIndex(playerIndex),
         objectType(static_cast<int>(objectType)) {}
-  
+
   inline bool isBuilding() const { return objectType == 0; }
   inline bool isUnit() const { return objectType == 1; }
   inline ObjectType GetObjectType() const { return static_cast<ObjectType>(objectType); }
@@ -27,12 +29,15 @@ class ServerObject {
   inline float GetHPInternalFloat() const { return hp; };
   inline void SetHP(float newHP) { hp = newHP; }
 
-  void GarrisonUnit(u32 unitId);
-  void UngarrisonUnit(u32 unitId);
+  void GarrisonUnit(ServerUnit* unit);
+  void UngarrisonUnit(ServerUnit* unit);
 
   // Returns the IDs of the units that are garrisoned.
-  inline const std::vector<u32>& GetGarrisonedUnits() const { return garrisonedUnits; }
+  inline const std::vector<ServerUnit*>& GetGarrisonedUnits() const { return garrisonedUnits; }
   inline int GetGarrisonedUnitsCount() const { return garrisonedUnits.size(); }
+  
+  // TODO: Add function to generate a string that represents the unit for logging and debugging.
+  //       eg. Villager@(20,4)
   
  private:
   /// Current hitpoints of the object.
@@ -42,7 +47,7 @@ class ServerObject {
   u8 playerIndex;
   
   // The IDs of the units that are garrisoned.
-  std::vector<u32> garrisonedUnits;
+  std::vector<ServerUnit*> garrisonedUnits;
   
   /// 0 for buildings, 1 for units.
   u8 objectType;

--- a/src/FreeAge/server/object.hpp
+++ b/src/FreeAge/server/object.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cmath>
+#include <vector>
 
 #include "FreeAge/common/free_age.hpp"
 #include "FreeAge/common/object_types.hpp"
@@ -25,6 +26,13 @@ class ServerObject {
   inline u32 GetHP() const { return std::round(hp); }
   inline float GetHPInternalFloat() const { return hp; };
   inline void SetHP(float newHP) { hp = newHP; }
+
+  void GarrisonUnit(u32 unitId);
+  void UngarrisonUnit(u32 unitId);
+
+  // Returns the IDs of the units that are garrisoned.
+  inline const std::vector<u32>& GetGarrisonedUnits() const { return garrisonedUnits; }
+  inline int GetGarrisonedUnitsCount() const { return garrisonedUnits.size(); }
   
  private:
   /// Current hitpoints of the object.
@@ -32,6 +40,9 @@ class ServerObject {
   float hp;
   
   u8 playerIndex;
+  
+  // The IDs of the units that are garrisoned.
+  std::vector<u32> garrisonedUnits;
   
   /// 0 for buildings, 1 for units.
   u8 objectType;

--- a/src/FreeAge/server/object.hpp
+++ b/src/FreeAge/server/object.hpp
@@ -32,7 +32,7 @@ class ServerObject {
   void GarrisonUnit(ServerUnit* unit);
   void UngarrisonUnit(ServerUnit* unit);
 
-  // Returns the IDs of the units that are garrisoned.
+  // Returns the units that are garrisoned.
   inline const std::vector<ServerUnit*>& GetGarrisonedUnits() const { return garrisonedUnits; }
   inline int GetGarrisonedUnitsCount() const { return garrisonedUnits.size(); }
   
@@ -46,7 +46,7 @@ class ServerObject {
   
   u8 playerIndex;
   
-  // The IDs of the units that are garrisoned.
+  // The units that are garrisoned.
   std::vector<ServerUnit*> garrisonedUnits;
   
   /// 0 for buildings, 1 for units.

--- a/src/FreeAge/server/unit.cpp
+++ b/src/FreeAge/server/unit.cpp
@@ -14,38 +14,33 @@ ServerUnit::ServerUnit(int playerIndex, UnitType type, const QPointF& mapCoord)
   SetHP(GetUnitMaxHP(type));
 }
 
-void ServerUnit::SetTarget(u32 targetObjectId, ServerObject* targetObject, bool isManualTargeting) {
-  InteractionType interaction = GetInteractionType(this, targetObject);
-  
+void ServerUnit::SetTarget(u32 targetObjectId, ServerObject* targetObject, bool isManualTargeting, InteractionType interaction) {
+  targetObjectInteraction = interaction;
+  if (interaction == InteractionType::Unknown) {
+    interaction = GetInteractionType(this, targetObject);
+    // keep the targetObjectInteraction with the value of Unknown
+  }
+
   if (interaction == InteractionType::Construct) {
     type = IsMaleVillager(type) ? UnitType::MaleVillagerBuilder : UnitType::FemaleVillagerBuilder;
-    SetTargetInternal(targetObjectId, targetObject, isManualTargeting);
-    return;
   } else if (interaction == InteractionType::CollectBerries) {
     type = IsMaleVillager(type) ? UnitType::MaleVillagerForager : UnitType::FemaleVillagerForager;
-    SetTargetInternal(targetObjectId, targetObject, isManualTargeting);
-    return;
   } else if (interaction == InteractionType::CollectWood) {
     type = IsMaleVillager(type) ? UnitType::MaleVillagerLumberjack : UnitType::FemaleVillagerLumberjack;
-    SetTargetInternal(targetObjectId, targetObject, isManualTargeting);
-    return;
   } else if (interaction == InteractionType::CollectGold) {
     type = IsMaleVillager(type) ? UnitType::MaleVillagerGoldMiner : UnitType::FemaleVillagerGoldMiner;
-    SetTargetInternal(targetObjectId, targetObject, isManualTargeting);
-    return;
   } else if (interaction == InteractionType::CollectStone) {
     type = IsMaleVillager(type) ? UnitType::MaleVillagerStoneMiner : UnitType::FemaleVillagerStoneMiner;
-    SetTargetInternal(targetObjectId, targetObject, isManualTargeting);
-    return;
-  } else if (interaction == InteractionType::DropOffResource) {
-    SetTargetInternal(targetObjectId, targetObject, isManualTargeting);
-    return;
-  } else if (interaction == InteractionType::Attack) {
-    SetTargetInternal(targetObjectId, targetObject, isManualTargeting);
+  } else if (interaction == InteractionType::DropOffResource ||
+      interaction == InteractionType::Attack ||
+      interaction == InteractionType::Garrison) {
+    // no change
+  } else {
+    LOG(WARNING) << "ServerUnit::SetTarget() did not handle the interaction type.";
     return;
   }
-  
-  LOG(WARNING) << "ServerUnit::SetTarget() did not handle the interaction type.";
+
+  SetTargetInternal(targetObjectId, targetObject, isManualTargeting);
 }
 
 void ServerUnit::RemoveTarget() {

--- a/src/FreeAge/server/unit.cpp
+++ b/src/FreeAge/server/unit.cpp
@@ -33,7 +33,8 @@ void ServerUnit::SetTarget(u32 targetObjectId, ServerObject* targetObject, bool 
     type = IsMaleVillager(type) ? UnitType::MaleVillagerStoneMiner : UnitType::FemaleVillagerStoneMiner;
   } else if (interaction == InteractionType::DropOffResource ||
       interaction == InteractionType::Attack ||
-      interaction == InteractionType::Garrison) {
+      interaction == InteractionType::Garrison ||
+      interaction == InteractionType::Ungarrison) {
     // no change
   } else {
     LOG(WARNING) << "ServerUnit::SetTarget() did not handle the interaction type.";
@@ -45,6 +46,7 @@ void ServerUnit::SetTarget(u32 targetObjectId, ServerObject* targetObject, bool 
 
 void ServerUnit::RemoveTarget() {
   targetObjectId = kInvalidObjectId;
+  targetObjectInteraction = InteractionType::Unknown;
 }
 
 void ServerUnit::SetMoveToTarget(const QPointF& mapCoord) {

--- a/src/FreeAge/server/unit.cpp
+++ b/src/FreeAge/server/unit.cpp
@@ -16,7 +16,7 @@ ServerUnit::ServerUnit(int playerIndex, UnitType type, const QPointF& mapCoord)
 
 void ServerUnit::SetTarget(u32 targetObjectId, ServerObject* targetObject, bool isManualTargeting, InteractionType interaction) {
   targetObjectInteraction = interaction;
-  if (interaction == InteractionType::Unknown) {
+  if (interaction == InteractionType::Default) {
     interaction = GetInteractionType(this, targetObject);
     // Keeps the targetObjectInteraction with the value of Unknown.
   }
@@ -46,7 +46,7 @@ void ServerUnit::SetTarget(u32 targetObjectId, ServerObject* targetObject, bool 
 
 void ServerUnit::RemoveTarget() {
   targetObjectId = kInvalidObjectId;
-  targetObjectInteraction = InteractionType::Unknown;
+  targetObjectInteraction = InteractionType::Default;
 }
 
 void ServerUnit::SetMoveToTarget(const QPointF& mapCoord) {

--- a/src/FreeAge/server/unit.cpp
+++ b/src/FreeAge/server/unit.cpp
@@ -33,8 +33,7 @@ void ServerUnit::SetTarget(u32 targetObjectId, ServerObject* targetObject, bool 
     type = IsMaleVillager(type) ? UnitType::MaleVillagerStoneMiner : UnitType::FemaleVillagerStoneMiner;
   } else if (interaction == InteractionType::DropOffResource ||
       interaction == InteractionType::Attack ||
-      interaction == InteractionType::Garrison ||
-      interaction == InteractionType::Ungarrison) {
+      interaction == InteractionType::Garrison) {
     // no change
   } else {
     LOG(WARNING) << "ServerUnit::SetTarget() did not handle the interaction type.";

--- a/src/FreeAge/server/unit.cpp
+++ b/src/FreeAge/server/unit.cpp
@@ -18,7 +18,7 @@ void ServerUnit::SetTarget(u32 targetObjectId, ServerObject* targetObject, bool 
   targetObjectInteraction = interaction;
   if (interaction == InteractionType::Unknown) {
     interaction = GetInteractionType(this, targetObject);
-    // keep the targetObjectInteraction with the value of Unknown
+    // Keeps the targetObjectInteraction with the value of Unknown.
   }
 
   if (interaction == InteractionType::Construct) {

--- a/src/FreeAge/server/unit.hpp
+++ b/src/FreeAge/server/unit.hpp
@@ -19,7 +19,7 @@ class ServerUnit : public ServerObject {
   inline const QPointF& GetMapCoord() const { return mapCoord; }
   inline void SetMapCoord(const QPointF& mapCoord) { this->mapCoord = mapCoord; }
   
-  inline bool IsGarrisoned() const { return garrisonedObjectId != kInvalidObjectId; }
+  inline bool IsGarrisoned() const { return garrisonedObject != nullptr; }
 
   inline UnitAction GetCurrentAction() const { return currentAction; }
   inline void SetCurrentAction(UnitAction newAction) { currentAction = newAction; }
@@ -55,7 +55,7 @@ class ServerUnit : public ServerObject {
   inline ResourceType GetCarriedResourceType() const { return carriedResourceType; }
   inline void SetCarriedResourceType(ResourceType type) { carriedResourceType = type; }
 
-  inline void SetGarrisonedInsideObject(u32 objectId) { garrisonedObjectId = objectId; }
+  inline void SetGarrisonedInsideObject(ServerObject* object) { garrisonedObject = object; }
   
   inline int GetCarriedResourceAmount() const { return static_cast<int>(carriedResourceAmount); }
   inline float GetCarriedResourceAmountInternalFloat() const { return carriedResourceAmount; }
@@ -108,8 +108,8 @@ class ServerUnit : public ServerObject {
   /// If this changes, the clients that see the unit need to be notified.
   QPointF currentMovementDirection = QPointF(0, 0);
   
-  /// The object in which the unit is garrisoned
-  u32 garrisonedObjectId = kInvalidObjectId;
+  /// The object in which the unit is garrisoned, or nullptr if not garrisoned.
+  ServerObject* garrisonedObject = nullptr;
 
   /// Amount of resources carried (for villagers).
   float carriedResourceAmount = 0;

--- a/src/FreeAge/server/unit.hpp
+++ b/src/FreeAge/server/unit.hpp
@@ -19,6 +19,8 @@ class ServerUnit : public ServerObject {
   inline const QPointF& GetMapCoord() const { return mapCoord; }
   inline void SetMapCoord(const QPointF& mapCoord) { this->mapCoord = mapCoord; }
   
+  inline bool IsGarrisoned() const { return garrisonedObjectId != kInvalidObjectId; }
+
   inline UnitAction GetCurrentAction() const { return currentAction; }
   inline void SetCurrentAction(UnitAction newAction) { currentAction = newAction; }
   
@@ -27,11 +29,13 @@ class ServerUnit : public ServerObject {
   
   /// Attempts to command the unit to interact with the given target object.
   /// If the unit cannot actually interact with that object, this call does nothing.
-  void SetTarget(u32 targetObjectId, ServerObject* targetObject, bool isManualTargeting);
+  void SetTarget(u32 targetObjectId, ServerObject* targetObject, bool isManualTargeting, InteractionType interaction);
   void RemoveTarget();
   inline u32 GetTargetObjectId() const { return targetObjectId; }
   inline u32 GetManuallyTargetedObjectId() const { return manuallyTargetedObjectId; }
   
+  inline InteractionType GetTargetObjectInteraction() const { return targetObjectInteraction; }
+
   /// Commands the unit to move to the given mapCoord.
   void SetMoveToTarget(const QPointF& mapCoord);
   inline bool HasMoveToTarget() const { return hasMoveToTarget; }
@@ -50,6 +54,8 @@ class ServerUnit : public ServerObject {
   
   inline ResourceType GetCarriedResourceType() const { return carriedResourceType; }
   inline void SetCarriedResourceType(ResourceType type) { carriedResourceType = type; }
+
+  inline void SetGarrisonedInsideObject(u32 objectId) { garrisonedObjectId = objectId; }
   
   inline int GetCarriedResourceAmount() const { return static_cast<int>(carriedResourceAmount); }
   inline float GetCarriedResourceAmountInternalFloat() const { return carriedResourceAmount; }
@@ -74,6 +80,9 @@ class ServerUnit : public ServerObject {
   /// The unit's target object (if any). Set to kInvalidObjectId if the unit does not have a target.
   u32 targetObjectId = kInvalidObjectId;
   
+  /// The interaction with the target object.
+  InteractionType targetObjectInteraction;
+
   /// The last object that was targeted manually (by the player). For example, if the player sends
   /// a villager to gather gold, and the villager is currently walking back to a mining camp to drop
   /// off the gold it has gathered, then manuallyTargetedObjectId is the gold mine, and targetObjectId
@@ -99,6 +108,9 @@ class ServerUnit : public ServerObject {
   /// If this changes, the clients that see the unit need to be notified.
   QPointF currentMovementDirection = QPointF(0, 0);
   
+  /// The object in which the unit is garrisoned
+  u32 garrisonedObjectId = kInvalidObjectId;
+
   /// Amount of resources carried (for villagers).
   float carriedResourceAmount = 0;
   

--- a/src/FreeAge/server/unit.hpp
+++ b/src/FreeAge/server/unit.hpp
@@ -56,6 +56,7 @@ class ServerUnit : public ServerObject {
   inline void SetCarriedResourceType(ResourceType type) { carriedResourceType = type; }
 
   inline void SetGarrisonedInsideObject(ServerObject* object) { garrisonedObject = object; }
+  inline ServerObject* GetGarrisonedInsideObject() const { return garrisonedObject; }
   
   inline int GetCarriedResourceAmount() const { return static_cast<int>(carriedResourceAmount); }
   inline float GetCarriedResourceAmountInternalFloat() const { return carriedResourceAmount; }


### PR DESCRIPTION
Almost full support for the garrison mechanics. For the full list check the commit names, I think all features have a separate commit (I don't think there is a need to list here again).

Left to do in the future (except from using the type stats instead of hard-coded values):
- Mechanics
  - Ungarrison a unit from a unit to empty space around (much easier to implement when there will be a unit with garrison capacity)
  - Town center bell (+ villager ungarrison and go back to work)
- Gui
  - Add health bars to the garrison units icons
- Game logic related
  - If relic, keep track of number of relics in PlayerStats
  - Bonus attack to some buildings from garrisoned units
  - Bonus speed to some units from garrisoned units
  - Heal garrisoned units

_(Update list or copy it to an issue or to a todo list ?)_