### PR TITLE
Worker map and multiple villager building speed

### DIFF
--- a/src/FreeAge/common/type_stats_data.cpp
+++ b/src/FreeAge/common/type_stats_data.cpp
@@ -494,8 +494,8 @@ void LoadGameData(GameData& gameData) {
 
   // Changes to game data for development testing
 
-  gameData.unitTypeStats[static_cast<int>(UnitType::MaleVillagerBuilder)].workRate = 4;
-  gameData.unitTypeStats[static_cast<int>(UnitType::FemaleVillagerBuilder)].workRate = 4;
+  gameData.unitTypeStats[static_cast<int>(UnitType::MaleVillagerBuilder)].workRate = 3;
+  gameData.unitTypeStats[static_cast<int>(UnitType::FemaleVillagerBuilder)].workRate = 3;
   gameData.unitTypeStats[static_cast<int>(UnitType::MaleVillager)].creationTime = 10;
   gameData.unitTypeStats[static_cast<int>(UnitType::Militia)].creationTime = 3;
   gameData.buildingTypeStats[static_cast<int>(BuildingType::Outpost)].lineOfSight = 300;

--- a/src/FreeAge/server/game.hpp
+++ b/src/FreeAge/server/game.hpp
@@ -150,6 +150,14 @@ class Game {
   inline PlayerStats* GetPlayerStats(int playerIndex) { return &(playerIndex == kGaiaPlayerIndex ? gaiaPlayer.GetPlayerStats() : playersInGame->at(playerIndex)->GetPlayerStats()); }
   inline const std::shared_ptr<PlayerInGame>& GetPlayerInGame(int index) { return playersInGame->at(index); }
   
+  /// A map from objects to all of their workers. Workers are considered:
+  /// - For buildings under construction: all the villagers building.
+  /// - For buildings/units being repaired: all the villagers repairing. TODO: implement
+  /// - For resources spots: all the villagers gathering. TODO: implement
+  /// - For farms: the villager farming. TODO: implement
+  /// The map is reconstructed in every frame.
+  std::multimap<ServerObject*, ServerUnit*> workers;
+
   /// Stores the object IDs that should be deleted at the end of the current
   /// game step. This list is required since we generally cannot directly delete
   //  arbitrary objects during the game step simulation. This is because


### PR DESCRIPTION
I originally tried adding a vector of ClentUnit pointers to the ServerObject to keep track of workers, but then there was too difficult and possible buggy to maintain the list. So my idea is to have a map from ServerObject* to ClentUnit*:

```c++
  /// A map from objects to all of their workers. Workers are considered:
  /// - For buildings under construction: all the villagers building.
  /// - For buildings/units being repaired: all the villagers repairing. TODO: implement
  /// - For resources spots: all the villagers gathering. TODO: implement
  /// - For farms: the villager farming. TODO: implement
  /// The map is reconstructed in every frame.
  std::multimap<ServerObject*, ServerUnit*> workers;
```

The key is that the list is cleared at the start of every simulation step and used in this way:

```c++
    bool firstBuilder = workers.count(targetBuilding) == 0;
    workers.emplace(targetBuilding, villager);
```

The advantage of is (compared to a vector in each object) that you don't have to find all the cases where the villagers stops building and go update the list.

Note: After the "too many villagers -> retask" is implemented we can figure out if the ServerUnit pointers are needed and if not the map could be reduced to a `std::map<ServerObject*, int>` keeping track of just the number not the actual units.

I think this design opens up a lot of things to be implemented easily. What do you think?

_This is quick pr before I go back to stats..._